### PR TITLE
[Feat] Zip가기 Bottom Sheet, 찜 버튼 현위치 기능

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@react-three/xr": "^5.7.1",
         "@types/three": "^0.152.1",
         "axios": "^1.7.8",
+        "framer-motion": "^11.18.1",
         "leva": "^0.9.35",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -3837,6 +3838,32 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.1.tgz",
+      "integrity": "sha512-EQa8c9lWVOm4zlz14MsBJWr8woq87HsNmsBnQNvcS0hs8uzw6HtGAxZyIU7EGTVpHD1C1n01ufxRyarXcNzpPg==",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs-extra": {
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
@@ -4539,6 +4566,19 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA=="
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@react-three/xr": "^5.7.1",
     "@types/three": "^0.152.1",
     "axios": "^1.7.8",
+    "framer-motion": "^11.18.1",
     "leva": "^0.9.35",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/components/BottomSheet/BottomSheet.tsx
+++ b/src/components/BottomSheet/BottomSheet.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { BOTTOM_SHEET_HEIGHT } from '../../constants/BottomSheetOption';
 import useBottomSheet from '../../hooks/useBottomSheet';
 import Header from './Header';
-import Content from './Content';
+import UserLikeZip from '../../pages/UserLikeZip';
 
 function BottomSheet() {
   const { sheet, content } = useBottomSheet();
@@ -17,7 +17,7 @@ function BottomSheet() {
     rounded-t-lg
     shadow-[0_0_10px_rgba(0,0,0,0.6)]
     bg-white
-    transition-transform duration-650 ease-out        
+    transition-transform duration-650 ease-out     
   `}
       style={{
         height: `${BOTTOM_SHEET_HEIGHT}px`,
@@ -27,7 +27,7 @@ function BottomSheet() {
     >
       <Header />
       <div className="overflow-auto overscroll-contain" ref={content}>
-        <Content />
+        <UserLikeZip />
       </div>
     </div>
   );

--- a/src/components/BottomSheet/BottomSheet.tsx
+++ b/src/components/BottomSheet/BottomSheet.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
-import { BOTTOM_SHEET_HEIGHT } from '../../constants/BottomSheetOption';
+import { BOTTOM_SHEET_HEIGHT, MAX_Y, MIN_Y } from '../../constants/BottomSheetOption';
 import useBottomSheet from '../../hooks/useBottomSheet';
 import Header from './Header';
-import UserLikeZip from '../../pages/UserLikeZip';
+interface BottomSheet {
+  view: React.ReactNode;
+  isOpen: boolean;
+}
 
-function BottomSheet() {
+function BottomSheet({ view, isOpen }: BottomSheet) {
   const { sheet, content } = useBottomSheet();
 
   return (
@@ -21,13 +24,13 @@ function BottomSheet() {
   `}
       style={{
         height: `${BOTTOM_SHEET_HEIGHT}px`,
-        transform: 'translateY(65px)',
+        transform: `translateY(${isOpen ? '-404px' : '65px'})`,
       }}
       ref={sheet}
     >
       <Header />
-      <div className="overflow-auto overscroll-contain" ref={content}>
-        <UserLikeZip />
+      <div className="overflow-auto overscroll-contain scrollbar-thin scrollbar-thumb-main_2" ref={content}>
+        {view}
       </div>
     </div>
   );

--- a/src/components/BottomSheet/BottomSheet.tsx
+++ b/src/components/BottomSheet/BottomSheet.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { BOTTOM_SHEET_HEIGHT } from '../../constants/BottomSheetOption';
+import useBottomSheet from '../../hooks/useBottomSheet';
+import Header from './Header';
+import Content from './Content';
+
+function BottomSheet() {
+  const { sheet, content } = useBottomSheet();
+
+  return (
+    <div
+      className={`
+    flex flex-col
+    absolute z-10
+    top-[calc(100%-90px)]
+    left-0 right-0
+    rounded-t-lg
+    shadow-[0_0_10px_rgba(0,0,0,0.6)]
+    bg-white
+    transition-transform duration-650 ease-out        
+  `}
+      style={{
+        height: `${BOTTOM_SHEET_HEIGHT}px`,
+        transform: 'translateY(65px)',
+      }}
+      ref={sheet}
+    >
+      <Header />
+      <div className="overflow-auto overscroll-contain" ref={content}>
+        <Content />
+      </div>
+    </div>
+  );
+}
+
+export default BottomSheet;

--- a/src/components/BottomSheet/Content.tsx
+++ b/src/components/BottomSheet/Content.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Content() {
+  return <div>하이</div>;
+}

--- a/src/components/BottomSheet/Content.tsx
+++ b/src/components/BottomSheet/Content.tsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export default function Content() {
-  return <div>하이</div>;
-}

--- a/src/components/BottomSheet/Header.tsx
+++ b/src/components/BottomSheet/Header.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Header = () => {
+  return (
+    <div className="h-6 relative pt-3 pb-1 rounded-t-lg rounded-br-lg">
+      <div className="w-10 h-1 rounded bg-gray-300 mx-auto"></div>
+    </div>
+  );
+};
+
+export default Header;

--- a/src/components/RoundButton.tsx
+++ b/src/components/RoundButton.tsx
@@ -1,20 +1,47 @@
-import { FaRegHeart } from 'react-icons/fa';
+import { useEffect, useState } from 'react';
+import { FaHeart, FaRegHeart } from 'react-icons/fa';
 import { TbCurrentLocation } from 'react-icons/tb';
 
 interface RoundButtonProps {
   type: string;
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  isLiked?: boolean;
 }
 
-const RoundButton = ({ type, onClick }: RoundButtonProps) => {
+const RoundButton = ({ type, onClick, isLiked }: RoundButtonProps) => {
+  const [isClicked, setIsClicked] = useState(false);
+
+  useEffect(() => {
+    if (isClicked) {
+      const timer = setTimeout(() => {
+        setIsClicked(false);
+      }, 400);
+
+      return () => clearTimeout(timer);
+    }
+  }, [isClicked]);
+
   const icon =
     type == 'heart' ? (
-      <FaRegHeart className="h-5 w-5 text-[#979797]" />
+      isLiked ? (
+        <FaHeart className="h-5 w-5 text-red_1" />
+      ) : (
+        <FaRegHeart className="h-5 w-5 text-[#979797]" />
+      )
     ) : (
-      <TbCurrentLocation className="h-6 w-6 text-[#979797]" />
+      <TbCurrentLocation
+        className={`h-6 w-6 ${isClicked ? 'text-blue-500' : 'text-[#979797]'} transition duration-400`}
+      />
     );
+
   return (
-    <button className="w-10 h-10 bg-white justify-items-center rounded-full" onClick={onClick}>
+    <button
+      className="w-10 h-10 bg-white justify-items-center rounded-full"
+      onClick={(e) => {
+        setIsClicked(true);
+        if (onClick) onClick(e);
+      }}
+    >
       {icon}
     </button>
   );

--- a/src/components/RoundButton.tsx
+++ b/src/components/RoundButton.tsx
@@ -3,16 +3,21 @@ import { TbCurrentLocation } from 'react-icons/tb';
 
 interface RoundButtonProps {
   type: string;
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
-const RoundButton = ({ type }: RoundButtonProps) => {
+const RoundButton = ({ type, onClick }: RoundButtonProps) => {
   const icon =
     type == 'heart' ? (
       <FaRegHeart className="h-5 w-5 text-[#979797]" />
     ) : (
       <TbCurrentLocation className="h-6 w-6 text-[#979797]" />
     );
-  return <button className="w-10 h-10 bg-white justify-items-center rounded-full">{icon}</button>;
+  return (
+    <button className="w-10 h-10 bg-white justify-items-center rounded-full" onClick={onClick}>
+      {icon}
+    </button>
+  );
 };
 
 export default RoundButton;

--- a/src/components/ZipPreview.tsx
+++ b/src/components/ZipPreview.tsx
@@ -1,0 +1,29 @@
+import { FaHeart } from 'react-icons/fa';
+import { FaStar } from 'react-icons/fa';
+
+const ZipPreview = () => {
+  return (
+    <div className="border-b-[0.5px] border-main_2 py-3 px-5 flex flex-col w-full ">
+      {/* 서점 이름 & 찜 버튼 */}
+      <div className="flex justify-between">
+        <p className="text-main_1 text-[14px] font-bold tracking-[-0.56px]">진시황 서점</p>
+        <div className="rounded-full border-[0.5px] border-[#BCB3B3] w-5 h-5 items-center flex justify-center">
+          <FaHeart className="w-3 h-3 fill-red_1" />
+        </div>
+      </div>
+      {/* 별점 & 카테고리 */}
+      <div className="mt-[10px] flex items-center gap-[6px]">
+        <div className="flex gap-1 items-center">
+          <FaStar className="w-[10px] h-[10px] fill-[#0000008A]" />
+          <p className="text-[12px] tracking-[-0.48px] text-[#979797]">4.3</p>
+        </div>
+        <div className="w-[1px] h-[10px] bg-[#D9D9D9]"></div>
+        <p className="text-[12px] tracking-[-0.48px] text-[#979797]">카페가 있는 서점</p>
+      </div>
+      {/* 주소 */}
+      <p className="text-[12px] tracking-[-0.48px] text-[#979797]">인천 연수구 청능대로113번길 37</p>
+    </div>
+  );
+};
+
+export default ZipPreview;

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -3,7 +3,6 @@ import Header from './Header';
 import MenuBar from './MenuBar';
 import { useEffect, useRef, useState } from 'react';
 
-// 로그인 이후 사용 가능한 페이지 -> 헤더와 해당 페이지가 렌더링 되는 것으로 레이아웃이 동일함
 const Layout = () => {
   const headerHeight = useRef<HTMLDivElement>(null);
   const menuBarHeight = useRef<HTMLDivElement>(null);
@@ -12,9 +11,11 @@ const Layout = () => {
   useEffect(() => {
     const updateHeights = () => {
       if (headerHeight.current && menuBarHeight.current) {
-        const header = headerHeight.current.offsetHeight;
-        const menubar = menuBarHeight.current.offsetHeight;
-        setHeights({ header, menubar });
+        requestAnimationFrame(() => {
+          const header = headerHeight.current?.offsetHeight || 0;
+          const menubar = menuBarHeight.current?.offsetHeight || 0;
+          setHeights({ header, menubar });
+        });
       }
     };
 
@@ -25,12 +26,12 @@ const Layout = () => {
   }, []);
 
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex h-screen flex-col">
       <div className="fixed w-full max-w-[500px]" ref={headerHeight}>
         <Header />
       </div>
       <main
-        className="flex-grow overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-gray-300"
+        className="overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-gray-300"
         style={{
           marginTop: `${heights.header}px`,
           marginBottom: `${heights.menubar}px`,

--- a/src/constants/BottomSheetOption.ts
+++ b/src/constants/BottomSheetOption.ts
@@ -1,3 +1,3 @@
-export const MIN_Y = 55; // 바텀 시트가 최대로 올라 갔을 때의 Y좌표 값
+export const MIN_Y = 280; // 바텀 시트가 최대로 올라 갔을 때의 Y좌표 값
 export const MAX_Y = window.innerHeight - 160; // 바텀 시트가 최대로 내려갔을 때의 Y좌표 값
 export const BOTTOM_SHEET_HEIGHT = window.innerHeight - MIN_Y; // 바텀시트 높이

--- a/src/constants/BottomSheetOption.ts
+++ b/src/constants/BottomSheetOption.ts
@@ -1,0 +1,3 @@
+export const MIN_Y = 55; // 바텀 시트가 최대로 올라 갔을 때의 Y좌표 값
+export const MAX_Y = window.innerHeight - 160; // 바텀 시트가 최대로 내려갔을 때의 Y좌표 값
+export const BOTTOM_SHEET_HEIGHT = window.innerHeight - MIN_Y; // 바텀시트 높이

--- a/src/hooks/useBottomSheet.ts
+++ b/src/hooks/useBottomSheet.ts
@@ -1,0 +1,142 @@
+import { useRef, useEffect } from 'react';
+import { MIN_Y, MAX_Y } from '../constants/BottomSheetOption';
+
+interface BottomSheetMetrics {
+  touchStart: {
+    sheetY: number;
+    touchY: number;
+  };
+  touchMove: {
+    prevTouchY?: number;
+    movingDirection: 'none' | 'down' | 'up';
+  };
+  isContentAreaTouched: boolean;
+}
+
+export default function useBottomSheet() {
+  const sheet = useRef<HTMLDivElement>(null);
+
+  const content = useRef<HTMLDivElement>(null);
+
+  const metrics = useRef<BottomSheetMetrics>({
+    touchStart: {
+      sheetY: 0,
+      touchY: 0,
+    },
+    touchMove: {
+      prevTouchY: 0,
+      movingDirection: 'none',
+    },
+    isContentAreaTouched: false,
+  });
+
+  useEffect(() => {
+    const canUserMoveBottomSheet = () => {
+      const { touchMove, isContentAreaTouched } = metrics.current;
+
+      if (!isContentAreaTouched) {
+        return true;
+      }
+
+      if (sheet.current!.getBoundingClientRect().y !== MIN_Y) {
+        return true;
+      }
+
+      if (touchMove.movingDirection === 'down') {
+        return content.current!.scrollTop <= 0;
+      }
+      return false;
+    };
+
+    const handleTouchStart = (e: TouchEvent) => {
+      const { touchStart } = metrics.current;
+      touchStart.sheetY = sheet.current!.getBoundingClientRect().y;
+      touchStart.touchY = e.touches[0].clientY;
+    };
+
+    const handleTouchMove = (e: TouchEvent) => {
+      const { touchStart, touchMove } = metrics.current;
+      const currentTouch = e.touches[0];
+
+      if (touchMove.prevTouchY === undefined) {
+        touchMove.prevTouchY = touchStart.touchY;
+      }
+
+      if (touchMove.prevTouchY === 0) {
+        // 맨 처음 앱 시작하고 시작시
+        touchMove.prevTouchY = touchStart.touchY;
+      }
+
+      if (touchMove.prevTouchY < currentTouch.clientY) {
+        touchMove.movingDirection = 'down';
+      }
+
+      if (touchMove.prevTouchY > currentTouch.clientY) {
+        touchMove.movingDirection = 'up';
+      }
+
+      if (canUserMoveBottomSheet()) {
+        e.preventDefault();
+
+        const touchOffset = currentTouch.clientY - touchStart.touchY;
+        let nextSheetY = touchStart.sheetY + touchOffset;
+
+        if (nextSheetY <= MIN_Y) {
+          nextSheetY = MIN_Y;
+        }
+
+        if (nextSheetY >= MAX_Y) {
+          nextSheetY = MAX_Y;
+        }
+
+        sheet.current!.style.setProperty('transform', `translateY(${nextSheetY - MAX_Y}px)`); //바닥 만큼은 빼야쥬...
+      } else {
+        document.body.style.overflowY = 'hidden';
+      }
+    };
+
+    const handleTouchEnd = (e: TouchEvent) => {
+      document.body.style.overflowY = 'auto';
+      const { touchMove } = metrics.current;
+
+      // Snap Animation
+      const currentSheetY = sheet.current!.getBoundingClientRect().y;
+
+      if (currentSheetY !== MIN_Y) {
+        if (touchMove.movingDirection === 'down') {
+          sheet.current!.style.setProperty('transform', 'translateY(65px)');
+        }
+
+        if (touchMove.movingDirection === 'up') {
+          sheet.current!.style.setProperty('transform', `translateY(${MIN_Y - MAX_Y}px)`);
+        }
+      }
+
+      // metrics 초기화.
+      metrics.current = {
+        touchStart: {
+          sheetY: 0,
+          touchY: 0,
+        },
+        touchMove: {
+          prevTouchY: 0,
+          movingDirection: 'none',
+        },
+        isContentAreaTouched: false,
+      };
+    };
+
+    sheet.current!.addEventListener('touchstart', handleTouchStart);
+    sheet.current!.addEventListener('touchmove', handleTouchMove);
+    sheet.current!.addEventListener('touchend', handleTouchEnd);
+  }, []);
+
+  useEffect(() => {
+    const handleTouchStart = () => {
+      metrics.current!.isContentAreaTouched = true;
+    };
+    content.current!.addEventListener('touchstart', handleTouchStart);
+  }, []);
+
+  return { sheet, content };
+}

--- a/src/hooks/useGeolocation.ts
+++ b/src/hooks/useGeolocation.ts
@@ -1,0 +1,37 @@
+import { useState, useEffect } from 'react';
+
+interface ILocation {
+  latitude: number;
+  longitude: number;
+}
+
+export const useGeoLocation = (options = {}) => {
+  const [location, setLocation] = useState<ILocation>();
+  const [error, setError] = useState('');
+
+  const handleSuccess = (pos: GeolocationPosition) => {
+    const { latitude, longitude } = pos.coords;
+
+    setLocation({
+      latitude,
+      longitude,
+    });
+  };
+
+  const handleError = (err: GeolocationPositionError) => {
+    setError(err.message);
+  };
+
+  useEffect(() => {
+    const { geolocation } = navigator;
+
+    if (!geolocation) {
+      setError('Geolocation is not supported.');
+      return;
+    }
+
+    geolocation.getCurrentPosition(handleSuccess, handleError, options);
+  }, [options]);
+
+  return { location, error };
+};

--- a/src/pages/UserLikeZip.tsx
+++ b/src/pages/UserLikeZip.tsx
@@ -1,0 +1,36 @@
+import { FaHeart } from 'react-icons/fa';
+import { FaLocationDot } from 'react-icons/fa6';
+import ZipPreview from '../components/ZipPreview';
+
+export default function userLikeZip() {
+  return (
+    <div className="flex mt-[15px] items-center justify-center w-full flex-col px-[30px] mb-[70px]">
+      {/* 제목 및 개수 */}
+      <div className="flex items-center justify-center gap-2">
+        <div className="rounded-full border-[0.5px] border-[#BCB3B3] w-5 h-5 items-center flex justify-center">
+          <FaHeart className="w-3 h-3 fill-red_1" />
+        </div>
+        <div className="text-main_1 text-[16px] font-medium">내가 찜한 서점</div>
+      </div>
+      {/* 개수 */}
+      <div className="flex items-center gap-1 mt-1">
+        <FaLocationDot className="w-3 h-3 fill-[#CFCCD4]" />
+        <div className="text-[13px] text-[#CFCCD4] font-medium">12개</div>
+      </div>
+      {/* 필터 */}
+      <div className="mt-[11px] flex justify-start items-start w-full border-b-[0.5px] border-[#979797]">
+        <div className="text-[14px] p-2 tracking-[-0.48px]">전체</div>
+        <div className="text-[14px] p-2 tracking-[-0.48px]">카페가 있는 서점</div>
+        <div className="text-[14px] p-2 tracking-[-0.48px]">독립서점</div>
+        <div className="text-[14px] p-2 tracking-[-0.48px]">아동서점</div>
+      </div>
+      {/* 서점들 */}
+      <ZipPreview />
+      <ZipPreview />
+      <ZipPreview />
+      <ZipPreview />
+      <ZipPreview />
+      <ZipPreview />
+    </div>
+  );
+}

--- a/src/pages/Zip.tsx
+++ b/src/pages/Zip.tsx
@@ -1,8 +1,10 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import SearchBar from '../components/SearchBar';
 import CategoryButton from '../components/CategoryButton';
 import RoundButton from '../components/RoundButton';
 import BottomSheet from '../components/BottomSheet/BottomSheet';
+import UserLikeZip from './UserLikeZip';
+import { useGeoLocation } from '../hooks/useGeolocation';
 
 declare global {
   interface Window {
@@ -10,7 +12,18 @@ declare global {
   }
 }
 
+const geolocationOptions = {
+  enableHighAccuracy: true,
+  timeout: 1000 * 30,
+  maximumAge: 1000 * 3600 * 24,
+};
+
 const Zip = () => {
+  const [bottomSheetContent, setBottomSheetContent] = useState<React.ReactNode>(null);
+  const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
+  const [isLiked, setIsLiked] = useState<boolean>(false);
+  const { location, error } = useGeoLocation(geolocationOptions);
+
   useEffect(() => {
     let container = document.getElementById(`map`);
     let options = {
@@ -22,11 +35,38 @@ const Zip = () => {
   }, []);
 
   const handleHeart = () => {
-    // 찜한 목록들 마커로 보여주기 && 아이콘 색깔 바꿔야되는데...?
+    // 찜한 목록들 마커로 보여주기 추가 필요
+    if (isLiked) {
+      setIsLiked(false);
+      setIsBottomSheetOpen(false);
+      setBottomSheetContent(null);
+    } else {
+      setIsLiked(true);
+      setBottomSheetContent(<UserLikeZip />);
+      setIsBottomSheetOpen(true);
+    }
   };
 
   const handleCurrentLocation = () => {
-    // 현위치로 돌아오기
+    if (location) {
+      const mapContainer = document.getElementById('map');
+      if (mapContainer) {
+        const options = {
+          center: new window.kakao.maps.LatLng(location.latitude, location.longitude),
+          level: 3,
+        };
+
+        const map = new window.kakao.maps.Map(mapContainer, options);
+
+        const marker = new window.kakao.maps.Marker({
+          position: new window.kakao.maps.LatLng(location.latitude, location.longitude),
+        });
+        marker.setMap(map);
+      }
+    } else if (error) {
+      console.error('Geolocation Error:', error);
+      alert('현재 위치를 가져올 수 없습니다. 위치 서비스를 확인해주세요.');
+    }
   };
 
   return (
@@ -47,12 +87,12 @@ const Zip = () => {
         </div>
         {/* 찜버튼 & 현재위치 */}
         <div className="mt-3 flex flex-col gap-3 items-end px-[10px] pointer-events-auto">
-          <RoundButton type="heart" onClick={handleHeart} />
+          <RoundButton type="heart" onClick={handleHeart} isLiked={isLiked} />
           <RoundButton type="current" onClick={handleCurrentLocation} />
         </div>
       </div>
       <div id="map" className="w-full h-full" />
-      <BottomSheet />
+      <BottomSheet view={bottomSheetContent} isOpen={isBottomSheetOpen} />
     </div>
   );
 };

--- a/src/pages/Zip.tsx
+++ b/src/pages/Zip.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import SearchBar from '../components/SearchBar';
 import CategoryButton from '../components/CategoryButton';
 import RoundButton from '../components/RoundButton';
+import BottomSheet from '../components/BottomSheet/BottomSheet';
 
 declare global {
   interface Window {
@@ -20,8 +21,16 @@ const Zip = () => {
     let map = new window.kakao.maps.Map(container, options);
   }, []);
 
+  const handleHeart = () => {
+    // 찜한 목록들 마커로 보여주기 && 아이콘 색깔 바꿔야되는데...?
+  };
+
+  const handleCurrentLocation = () => {
+    // 현위치로 돌아오기
+  };
+
   return (
-    <div className="w-full h-full relative">
+    <div className="w-full h-full relative overflow-hidden">
       <div className="absolute top-0 left-0 w-full h-full flex flex-col z-10 pointer-events-none">
         {/* 검색바 */}
         <div className="w-full mt-[18px] px-[10px] pointer-events-auto">
@@ -38,11 +47,12 @@ const Zip = () => {
         </div>
         {/* 찜버튼 & 현재위치 */}
         <div className="mt-3 flex flex-col gap-3 items-end px-[10px] pointer-events-auto">
-          <RoundButton type="heart" />
-          <RoundButton type="current" />
+          <RoundButton type="heart" onClick={handleHeart} />
+          <RoundButton type="current" onClick={handleCurrentLocation} />
         </div>
       </div>
       <div id="map" className="w-full h-full" />
+      <BottomSheet />
     </div>
   );
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,6 +11,7 @@ export default {
         main_2: '#DBE5FF',
         main_3: '#4869C3',
         main_4: '#E1ECF6',
+        red_1: '#FF0101',
       },
       backgroundImage: {
         'key-gradient': 'linear-gradient(180deg, #E1ECF6 0%, #DAE4FD 31%, #DBE5FD 61.5%, #EAF1F8 100%)',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,5 +18,5 @@ export default {
       },
     },
   },
-  plugins: [require('tailwind-scrollbar-hide')],
+  plugins: [require('tailwind-scrollbar'), require('tailwind-scrollbar-hide')],
 };


### PR DESCRIPTION
## 🔥 Issues
#14 

## ✅ What to do

- [x] Bottom Sheet
- [x] 내가 찜한 서점 UI
- [x] 현위치 버튼 클릭시 현위치 마커 표시

## 📄 Description
- **Bottom Sheet**는 `zip` 컴포넌트 내부에서만 사용되며, `zip` 컴포넌트 안에서 호출되고 있다. 기본적으로 Bottom Sheet는 메뉴바 위에 위치하며, 드래그하여 위로 올리면 표시된다.
- **현위치 버튼**을 누르면 버튼 색상이 0.5초 동안 변경되며, 사용자의 현재 위치로 지도 중심이 이동하고 마커가 표시된다.
- **찜 버튼**을 누르면 Bottom Sheet가 자동으로 열리며, 사용자가 찜한 서점 리스트가 표시된다.

## 🤔 Considerations
1. **Bottom Sheet가 메뉴바를 가리는 문제 해결**  
   - 초기에는 Bottom Sheet가 메뉴바를 가리는 문제가 있었다. 원인은 `fixed`로 설정했기 때문이었다.  
   - `fixed`는 뷰포트를 기준으로 동작하지만, 부모 요소 기준으로 위치를 정하려면 `absolute`를 사용해야 했다. `absolute`로 변경하니 메뉴바 위로 잘 배치되었다...
   
2. **현위치 버튼 색상 변경**  
   - 버튼 클릭 시 0.5초간 색상이 변경된 후 원래 색상으로 돌아가도록 구현해야 했다.  
   - `onClick` 함수를 이미 사용하고 있었고, 부모 컴포넌트로부터 `onClick`을 props로 전달받고 있는 상황이었다.  
   - 이를 해결하기 위해 버튼 컴포넌트에서 `onClick` 이벤트를 감지하면서도 부모 컴포넌트의 `onClick`을 호출하도록 아래와 같이 처리했다:
     ```jsx
     onClick={(e) => {
       setIsClicked(true);
       if (onClick) onClick(e);
     }}
     ```

3. **Layout에서 메뉴바와 헤더 사이즈 계산 문제**  
   - Layout에서 헤더와 메뉴바 사이즈를 제외한 나머지 영역을 `Outlet`이 사용하도록 설정했으나, 빈 여백이 생기는 문제가 있었다.  
   - 원인은 DOM 요소 크기를 정확히 계산하기 전에 계산이 시작되는 것이었다.  
   - 이를 해결하기 위해 `requestAnimationFrame`을 사용하여 DOM 요소가 렌더링된 후 크기를 계산하도록 수정했다.

## 🛠️ Improvements to Make
- **Bottom Sheet 3단계 구현**  
  - 현재 Bottom Sheet는 두 단계로 동작한다.  
  - 디자인 요구사항에 맞게 한 번 올리면 중간 단계(`MID_Y`), 다시 올리면 전체 화면을 차지하는 모달(`MIN_Y`) 상태로 전환되도록 수정이 필요하다.



## 👀 References
* https://velog.io/@boris0716/%EB%A6%AC%EC%95%A1%ED%8A%B8%EC%97%90%EC%84%9C-Bottom-Sheet-%EB%A7%8C%EB%93%A4%EA%B8%B0-%EC%9E%91%EC%84%B1%EC%A4%91#%EC%B2%AB-%EB%B2%88%EC%A7%B8-useeffect
* https://doooodle932.tistory.com/159
<img width="341" alt="image" src="https://github.com/user-attachments/assets/4361c8cf-ca09-4700-b93b-b362a55bd3f6" />
<img width="339" alt="image" src="https://github.com/user-attachments/assets/82072463-0e53-458e-83f5-3233f3b791d5" />

