### PR TITLE
[Feat] 카테고리별 서점 & 서점 검색 api 연동 

### DIFF
--- a/src/api/zip.api.ts
+++ b/src/api/zip.api.ts
@@ -1,8 +1,20 @@
 import instance from './instance';
 
+// 서점 검색
 export const searchBookstore = async (name: string) => {
   try {
     const response = await instance.get(`/api/bookstores/search?keyword=${name}`);
+    if (response.status == 200) {
+      return response.data;
+    }
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+export const getCategoryBookstore = async (category: string) => {
+  try {
+    const response = await instance.get(`api/bookstores?category=${category}`);
     if (response.status == 200) {
       return response.data;
     }

--- a/src/components/Zip/SearchBar.tsx
+++ b/src/components/Zip/SearchBar.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { CiSearch } from 'react-icons/ci';
 
 interface SearchBarProps {
@@ -6,20 +7,28 @@ interface SearchBarProps {
   onSearch: () => void;
 }
 const SearchBar = ({ setSearchWord, searchWord, onSearch }: SearchBarProps) => {
+  const [isComposing, setIsComposing] = useState(false);
+
   const handleEnter = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') {
+    if (!isComposing && e.key === 'Enter') {
       onSearch();
     }
   };
+
   return (
     <label className="relative block">
-      <CiSearch className="text-main_1 absolute left-3 top-1/2 -translate-y-1/2 w-[18px] h-[18px]" />
+      <CiSearch className="absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-main_1" />
       <input
         placeholder="서점 이름, 지역 검색"
-        className="w-full pl-[46px] text-[14px] py-[10px] bg-white rounded-[12px] focus:outline-none focus:ring-1 focus:ring-main_1"
+        className="w-full rounded-[12px] bg-white py-[10px] pl-[46px] text-[14px] focus:outline-none focus:ring-1 focus:ring-main_1"
         onChange={(e) => setSearchWord(e.target.value)}
         value={searchWord}
         onKeyDown={handleEnter}
+        onCompositionStart={() => setIsComposing(true)}
+        onCompositionEnd={(e) => {
+          setIsComposing(false);
+          setSearchWord(e.currentTarget.value);
+        }}
       />
     </label>
   );

--- a/src/components/Zip/ZipPreview.tsx
+++ b/src/components/Zip/ZipPreview.tsx
@@ -3,6 +3,7 @@ import { FaStar } from 'react-icons/fa';
 import { useBottomSheetStore } from '../../store/bottomSheetStore';
 import ZipDetail from '../../pages/Zip/ZipDetail';
 import { getZipPreview } from '../../model/zip.model';
+import { BOOKSTORE_OPTIONS } from '../../pages/Zip/Zip';
 
 interface ZipPreviewProps {
   bookstore: getZipPreview;
@@ -13,6 +14,12 @@ const ZipPreview = ({ bookstore }: ZipPreviewProps) => {
 
   const openDetail = () => {
     setBottomSheet(({ currentState }) => <ZipDetail currentState={currentState} />, '서점 상세 정보');
+  };
+
+  // 카테고리 이름 변환
+  const getLabelByKey = (key: string) => {
+    const option = BOOKSTORE_OPTIONS.find((option) => option.key === key);
+    return option ? option.label : '';
   };
 
   console.log(bookstore);
@@ -33,7 +40,7 @@ const ZipPreview = ({ bookstore }: ZipPreviewProps) => {
           <p className="text-[12px] tracking-[-0.48px] text-[#979797]">4.3</p>
         </div>
         <div className="h-[10px] w-[1px] bg-[#D9D9D9]"></div>
-        <p className="text-[12px] tracking-[-0.48px] text-[#979797]">{bookstore.bookstoreCategory}</p>
+        <p className="text-[12px] tracking-[-0.48px] text-[#979797]">{getLabelByKey(bookstore.bookstoreCategory)}</p>
       </div>
       {/* 주소 */}
       <p className="text-[12px] tracking-[-0.48px] text-[#979797]">{bookstore.address}</p>

--- a/src/components/Zip/ZipPreview.tsx
+++ b/src/components/Zip/ZipPreview.tsx
@@ -2,19 +2,26 @@ import { FaHeart } from 'react-icons/fa';
 import { FaStar } from 'react-icons/fa';
 import { useBottomSheetStore } from '../../store/bottomSheetStore';
 import ZipDetail from '../../pages/Zip/ZipDetail';
+import { getZipPreview } from '../../model/zip.model';
 
-const ZipPreview = () => {
+interface ZipPreviewProps {
+  bookstore: getZipPreview;
+}
+
+const ZipPreview = ({ bookstore }: ZipPreviewProps) => {
   const { setBottomSheet } = useBottomSheetStore();
 
   const openDetail = () => {
     setBottomSheet(({ currentState }) => <ZipDetail currentState={currentState} />, '서점 상세 정보');
   };
 
+  console.log(bookstore);
+
   return (
     <div className="flex w-full flex-col border-b-[0.5px] border-main_2 px-5 py-3" onClick={openDetail}>
       {/* 서점 이름 & 찜 버튼 */}
       <div className="flex justify-between">
-        <p className="text-[14px] font-bold tracking-[-0.56px] text-main_1">진시황 서점</p>
+        <p className="text-[14px] font-bold tracking-[-0.56px] text-main_1">{bookstore.name}</p>
         <div className="flex h-5 w-5 items-center justify-center rounded-full border-[0.5px] border-[#BCB3B3]">
           <FaHeart className="h-3 w-3 fill-red_1" />
         </div>
@@ -26,10 +33,10 @@ const ZipPreview = () => {
           <p className="text-[12px] tracking-[-0.48px] text-[#979797]">4.3</p>
         </div>
         <div className="h-[10px] w-[1px] bg-[#D9D9D9]"></div>
-        <p className="text-[12px] tracking-[-0.48px] text-[#979797]">카페가 있는 서점</p>
+        <p className="text-[12px] tracking-[-0.48px] text-[#979797]">{bookstore.bookstoreCategory}</p>
       </div>
       {/* 주소 */}
-      <p className="text-[12px] tracking-[-0.48px] text-[#979797]">인천 연수구 청능대로113번길 37</p>
+      <p className="text-[12px] tracking-[-0.48px] text-[#979797]">{bookstore.address}</p>
     </div>
   );
 };

--- a/src/components/Zip/ZipPreview.tsx
+++ b/src/components/Zip/ZipPreview.tsx
@@ -22,8 +22,6 @@ const ZipPreview = ({ bookstore }: ZipPreviewProps) => {
     return option ? option.label : '';
   };
 
-  console.log(bookstore);
-
   return (
     <div className="flex w-full flex-col border-b-[0.5px] border-main_2 px-5 py-3" onClick={openDetail}>
       {/* 서점 이름 & 찜 버튼 */}

--- a/src/model/zip.model.ts
+++ b/src/model/zip.model.ts
@@ -1,0 +1,10 @@
+// 검색 조회
+export interface getZipPreview {
+  address: string;
+  bookstoreCategory: string;
+  bookstoreId: number;
+  description: string;
+  hours: string;
+  name: string;
+  phone: string;
+}

--- a/src/pages/Zip/SearchZip.tsx
+++ b/src/pages/Zip/SearchZip.tsx
@@ -24,9 +24,6 @@ export default function SearchZip({ searchResults, currentState }: SearchZipProp
     setIsOpen(false);
   };
 
-  console.log(searchResults);
-  console.log(currentState);
-
   return (
     <div className={`flex w-full flex-col px-[32px] ${currentState == 'max' ? 'pt-[10px]' : 'pt-[28px]'}`}>
       {/* 필터 */}

--- a/src/pages/Zip/SearchZip.tsx
+++ b/src/pages/Zip/SearchZip.tsx
@@ -2,9 +2,10 @@ import { IoIosArrowDown } from 'react-icons/io';
 import ZipPreview from '../../components/Zip/ZipPreview';
 import { useState } from 'react';
 import Ping from '../../../public/icons/zip/ping.svg?react';
+import { getZipPreview } from '../../model/zip.model';
 
 interface SearchZipProps {
-  searchResults: any[];
+  searchResults: getZipPreview[];
   currentState: string;
 }
 
@@ -22,6 +23,9 @@ export default function SearchZip({ searchResults, currentState }: SearchZipProp
     setCurrentFilter(key);
     setIsOpen(false);
   };
+
+  console.log(searchResults);
+  console.log(currentState);
 
   return (
     <div className={`flex w-full flex-col px-[32px] ${currentState == 'max' ? 'pt-[10px]' : 'pt-[28px]'}`}>
@@ -50,16 +54,13 @@ export default function SearchZip({ searchResults, currentState }: SearchZipProp
       )}
       <div className="mt-[12px] h-[0.5px] w-full bg-[#979797]"></div>
       {/* 검색결과 */}
-      {searchResults[0] == '' ? (
+      {searchResults.length === 0 ? (
         <div className="flex w-full flex-col items-center justify-center">
           <Ping className="mb-[5px] mt-[30px]" />
           <p className="text-[14px] text-[#979797]">검색된 서점이 없어요!</p>
         </div>
       ) : (
-        <>
-          <ZipPreview />
-          <ZipPreview />
-        </>
+        searchResults.map((zip, index) => <ZipPreview key={index} bookstore={zip} />)
       )}
     </div>
   );

--- a/src/pages/Zip/UserLikeZip.tsx
+++ b/src/pages/Zip/UserLikeZip.tsx
@@ -94,6 +94,7 @@ export default function userLikeZip({ currentState }: { currentState: string }) 
           </div>
         ) : (
           <>
+            {/* <ZipPreview />
             <ZipPreview />
             <ZipPreview />
             <ZipPreview />
@@ -104,8 +105,7 @@ export default function userLikeZip({ currentState }: { currentState: string }) 
             <ZipPreview />
             <ZipPreview />
             <ZipPreview />
-            <ZipPreview />
-            <ZipPreview />
+            <ZipPreview /> */}
           </>
         )}
       </div>

--- a/src/pages/Zip/Zip.tsx
+++ b/src/pages/Zip/Zip.tsx
@@ -9,8 +9,14 @@ import SearchZip from './SearchZip';
 import { useBottomSheetStore } from '../../store/bottomSheetStore';
 import { useMap } from '../../hooks/useMap';
 import { useCurrentLocation } from '../../hooks/useCurrentLocation';
-import { searchBookstore } from '../../api/zip.api';
+import { getCategoryBookstore, searchBookstore } from '../../api/zip.api';
 import { getZipPreview } from '../../model/zip.model';
+
+export const BOOKSTORE_OPTIONS = [
+  { key: 'INDEP', label: '📚 독립서점' },
+  { key: 'CAFE', label: '☕️ 카페가 있는 서점' },
+  { key: 'CHILD', label: '🐥 아동서점' },
+] as const;
 
 const Zip = () => {
   const [isLiked, setIsLiked] = useState<boolean>(false);
@@ -20,12 +26,6 @@ const Zip = () => {
   const [searchResults, setSearchResults] = useState<getZipPreview[]>([]);
   const { setBottomSheet, closeBottomSheet, isOpen } = useBottomSheetStore();
   const [prevView, setPrevView] = useState(() => useBottomSheetStore.getState().prevView || null);
-
-  const BOOKSTORE_OPTIONS = [
-    { key: 'indie', label: '📚 독립서점' },
-    { key: 'cafe', label: '☕️ 카페가 있는 서점' },
-    { key: 'children', label: '🐥 아동서점' },
-  ] as const;
 
   useMap(location?.latitude, location?.longitude);
   const handleCurrentLocation = useCurrentLocation(location, error);
@@ -42,11 +42,12 @@ const Zip = () => {
 
   useEffect(() => {
     if (currentBookstore) {
-      setSearchResults([]);
-      setBottomSheet(
-        ({ currentState }) => <SearchZip searchResults={searchResults} currentState={currentState} />,
-        '독립 서점',
-      );
+      getCategoryBookstore(currentBookstore).then((data) => {
+        setBottomSheet(
+          ({ currentState }) => <SearchZip searchResults={data} currentState={currentState} />,
+          '독립 서점',
+        );
+      });
     }
   }, [currentBookstore]);
 
@@ -57,7 +58,7 @@ const Zip = () => {
 
   const handleCategorySelect = (category: string) => {
     if (currentBookstore !== category) {
-      setIsLiked(false); // UI는 바뀌지만 바텀시트는 닫히지 않음
+      setIsLiked(false);
       setCurrentBookstore(category);
     } else {
       setCurrentBookstore(null);

--- a/src/pages/Zip/Zip.tsx
+++ b/src/pages/Zip/Zip.tsx
@@ -9,13 +9,15 @@ import SearchZip from './SearchZip';
 import { useBottomSheetStore } from '../../store/bottomSheetStore';
 import { useMap } from '../../hooks/useMap';
 import { useCurrentLocation } from '../../hooks/useCurrentLocation';
+import { searchBookstore } from '../../api/zip.api';
+import { getZipPreview } from '../../model/zip.model';
 
 const Zip = () => {
   const [isLiked, setIsLiked] = useState<boolean>(false);
   const { location, error } = useGeoLocation();
   const [currentBookstore, setCurrentBookstore] = useState<string | null>(null);
   const [searchWord, setSearchWord] = useState<string>('');
-  const [searchResults, setSearchResults] = useState<any[]>([]);
+  const [searchResults, setSearchResults] = useState<getZipPreview[]>([]);
   const { setBottomSheet, closeBottomSheet, isOpen } = useBottomSheetStore();
   const [prevView, setPrevView] = useState(() => useBottomSheetStore.getState().prevView || null);
 
@@ -40,7 +42,7 @@ const Zip = () => {
 
   useEffect(() => {
     if (currentBookstore) {
-      setSearchResults(['카페가 있는 서점']);
+      setSearchResults([]);
       setBottomSheet(
         ({ currentState }) => <SearchZip searchResults={searchResults} currentState={currentState} />,
         '독립 서점',
@@ -73,16 +75,18 @@ const Zip = () => {
     setIsLiked(false);
     // 검색 API 호출
     try {
-      setSearchResults(['진시황']);
+      searchBookstore(searchWord).then((data) => {
+        setSearchResults(data);
+
+        setBottomSheet(
+          ({ currentState }) => <SearchZip searchResults={data} currentState={currentState} />,
+          '검색 결과',
+        );
+      });
 
       // 모바일 환경에서 검색하면 키보드 닫아주기
       const searchInput = document.querySelector('input');
       if (searchInput) searchInput.blur(); // 포커스 해제
-
-      setBottomSheet(
-        ({ currentState }) => <SearchZip searchResults={searchResults} currentState={currentState} />,
-        '검색 결과',
-      );
     } catch (error) {
       console.error('검색 중 오류 발생:', error);
     }


### PR DESCRIPTION
## 🔥 Issues
#14 

## ✅ What to do

- [x] 서점 검색 시 한글 중복 입력 오류 수정
- [x] 서점 검색 api 연동
- [x] 카테고리별 서점 api 연동

## 📄 Description
* 서점 검색할 때 한글을 입력하면 마지막 글자가 

## 🤔 Considerations
### 한글 중복 입력 오류
* 서점 검색 기능에서 한글 입력 시 마지막 글자가 중복 입력되는 오류 발생
  * 이는 IME 입력(한글, 일본어 등)에서 조합 중(`composing` 상태)일 때 즉시 검색이 실행되면서 발생
  * `isComposing`을 활용하여 입력이 조합 중일 때는 검색 요청을 막고, 조합이 완료(`compositionend`)된 후에만 검색 요청 실행
  
### 비동기 문제
* 검색 후 데이터를 `setState`로 저장한 뒤, 즉시 하위 컴포넌트에 Props로 전달
  * 하지만 `setState`는 비동기적으로 동작하므로, 아직 상태 업데이트가 완료되지 않은 시점에서 하위 컴포넌트가 undefined 데이터를 받게 되는 것이었음
  * `setState` 호출 후 데이터를 사용하는 방식 → API 응답 데이터를 즉시 Props로 전달하는 방식으로 변경

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

스크린샷 또는 참고사항