### PR TITLE
[Feat] 서점 마커 표시 및 api 연동

### DIFF
--- a/src/api/zip.api.ts
+++ b/src/api/zip.api.ts
@@ -12,9 +12,22 @@ export const searchBookstore = async (name: string) => {
   }
 };
 
+// 카테고리 검색
 export const getCategoryBookstore = async (category: string) => {
   try {
     const response = await instance.get(`api/bookstores?category=${category}`);
+    if (response.status == 200) {
+      return response.data;
+    }
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+// 사용자가 찜한 서점
+export const getHeartBookstore = async () => {
+  try {
+    const response = await instance.get(`api/bookstores/liked`);
     if (response.status == 200) {
       return response.data;
     }

--- a/src/components/Zip/ZipPreview.tsx
+++ b/src/components/Zip/ZipPreview.tsx
@@ -35,7 +35,7 @@ const ZipPreview = ({ bookstore }: ZipPreviewProps) => {
       <div className="mt-[10px] flex items-center gap-[6px]">
         <div className="flex items-center gap-1">
           <FaStar className="h-[10px] w-[10px] fill-[#0000008A]" />
-          <p className="text-[12px] tracking-[-0.48px] text-[#979797]">4.3</p>
+          <p className="text-[12px] tracking-[-0.48px] text-[#979797]">{bookstore.rating}</p>
         </div>
         <div className="h-[10px] w-[1px] bg-[#D9D9D9]"></div>
         <p className="text-[12px] tracking-[-0.48px] text-[#979797]">{getLabelByKey(bookstore.bookstoreCategory)}</p>

--- a/src/hooks/useMap.ts
+++ b/src/hooks/useMap.ts
@@ -1,4 +1,6 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import { getLatLngFromAddress } from '../utils/getLatLngFromAddress';
+import { createCustomMarker } from '../utils/markerUtils';
 
 declare global {
   interface Window {
@@ -6,26 +8,63 @@ declare global {
   }
 }
 
-const defaultLatitude = 33.450701; // 기본 위도
-const defaultLongitude = 126.570667; // 기본 경도
+const defaultLatitude = 33.450701;
+const defaultLongitude = 126.570667;
 
-export const useMap = (latitude?: number, longitude?: number) => {
+export const useMap = (latitude?: number, longitude?: number, locations: { address: string }[] = []) => {
+  const [map, setMap] = useState<any>(null);
+  const [markers, setMarkers] = useState<any[]>([]);
+
   useEffect(() => {
-    const initializeMap = (lat: number, lng: number) => {
-      const container = document.getElementById('map');
-      if (container) {
-        const options = {
-          center: new window.kakao.maps.LatLng(lat, lng),
-          level: 3,
-        };
-        new window.kakao.maps.Map(container, options);
+    if (!window.kakao || !window.kakao.maps) return;
+
+    const container = document.getElementById('map');
+    if (!container) return;
+
+    const options = {
+      center: new window.kakao.maps.LatLng(latitude ?? defaultLatitude, longitude ?? defaultLongitude),
+      level: 3,
+    };
+
+    const newMap = new window.kakao.maps.Map(container, options);
+    setMap(newMap);
+  }, [latitude, longitude]);
+
+  useEffect(() => {
+    if (!map) return;
+
+    // 기존 마커 삭제
+    markers.forEach((marker) => marker.setMap(null));
+    setMarkers([]);
+
+    const addMarkers = async () => {
+      const bounds = new window.kakao.maps.LatLngBounds(); // 🔥 지도 범위 객체 생성
+
+      const newMarkers = await Promise.all(
+        locations.map(async ({ address }, index) => {
+          await new Promise((res) => setTimeout(res, index * 100)); // 🔥 API 요청 간격 100ms 추가
+
+          try {
+            const { lat, lng } = await getLatLngFromAddress(address);
+            const position = new window.kakao.maps.LatLng(lat, lng);
+            bounds.extend(position); // 🔥 지도 범위 확장
+
+            const marker = createCustomMarker(map, position);
+            return marker;
+          } catch (error) {
+            console.error(`주소 변환 실패: ${address}`, error);
+            return null;
+          }
+        }),
+      );
+
+      setMarkers(newMarkers.filter((marker) => marker !== null));
+
+      if (newMarkers.length > 0) {
+        map.setBounds(bounds); // 🔥 모든 마커가 보이도록 지도 확대/이동
       }
     };
 
-    if (latitude && longitude) {
-      initializeMap(latitude, longitude);
-    } else {
-      initializeMap(defaultLatitude, defaultLongitude);
-    }
-  }, [latitude, longitude]);
+    addMarkers();
+  }, [map, locations]);
 };

--- a/src/model/zip.model.ts
+++ b/src/model/zip.model.ts
@@ -3,8 +3,6 @@ export interface getZipPreview {
   address: string;
   bookstoreCategory: string;
   bookstoreId: number;
-  description: string;
-  hours: string;
+  rating: number;
   name: string;
-  phone: string;
 }

--- a/src/pages/Zip/UserLikeZip.tsx
+++ b/src/pages/Zip/UserLikeZip.tsx
@@ -1,8 +1,9 @@
 import { FaHeart } from 'react-icons/fa';
 import { FaLocationDot } from 'react-icons/fa6';
 import Ping from '../../../public/icons/zip/ping.svg?react';
-import ZipPreview from '../../components/Zip/ZipPreview';
 import { useEffect, useState } from 'react';
+import { getZipPreview } from '../../model/zip.model';
+import ZipPreview from '../../components/Zip/ZipPreview';
 
 export const FILTER_NAME = {
   ALL: 'all',
@@ -20,13 +21,13 @@ const FILTER_OPTIONS = [
 
 type FilterType = (typeof FILTER_NAME)[keyof typeof FILTER_NAME];
 
-export default function userLikeZip({ currentState }: { currentState: string }) {
-  const [isSelected, setIsSelected] = useState<FilterType>(FILTER_NAME.ALL);
-  const [bookstoreList, setBookstoreList] = useState<string>('');
+interface useLikeZipProps {
+  bookstoreList: getZipPreview[];
+  currentState: string;
+}
 
-  useEffect(() => {
-    // 서점 목록 받아오기
-  }, [isSelected]);
+export default function userLikeZip({ currentState, bookstoreList }: useLikeZipProps) {
+  const [isSelected, setIsSelected] = useState<FilterType>(FILTER_NAME.ALL);
 
   return (
     <div
@@ -46,7 +47,7 @@ export default function userLikeZip({ currentState }: { currentState: string }) 
       {/* 개수 */}
       <div className="mt-1 flex items-center gap-1">
         <FaLocationDot className="h-3 w-3 fill-[#CFCCD4]" />
-        <div className="text-[13px] font-medium text-[#CFCCD4]">12개</div>
+        <div className="text-[13px] font-medium text-[#CFCCD4]">{bookstoreList.length}개</div>
       </div>
       {/* 필터 */}
       <div className="mt-[11px] flex w-full items-start justify-start border-b-[0.5px] border-[#979797]">
@@ -87,26 +88,13 @@ export default function userLikeZip({ currentState }: { currentState: string }) 
           }
         }}
       >
-        {bookstoreList == '' ? (
+        {bookstoreList.length == 0 ? (
           <div className="flex w-full flex-col items-center justify-center">
             <Ping className="mb-[5px] mt-[30px]" />
             <p className="text-[14px] text-[#979797]">아직 찜한 서점이 없어요!</p>
           </div>
         ) : (
-          <>
-            {/* <ZipPreview />
-            <ZipPreview />
-            <ZipPreview />
-            <ZipPreview />
-            <ZipPreview />
-            <ZipPreview />
-            <ZipPreview />
-            <ZipPreview />
-            <ZipPreview />
-            <ZipPreview />
-            <ZipPreview />
-            <ZipPreview /> */}
-          </>
+          bookstoreList.map((zip, index) => <ZipPreview key={index} bookstore={zip} />)
         )}
       </div>
     </div>

--- a/src/pages/Zip/Zip.tsx
+++ b/src/pages/Zip/Zip.tsx
@@ -9,7 +9,7 @@ import SearchZip from './SearchZip';
 import { useBottomSheetStore } from '../../store/bottomSheetStore';
 import { useMap } from '../../hooks/useMap';
 import { useCurrentLocation } from '../../hooks/useCurrentLocation';
-import { getCategoryBookstore, searchBookstore } from '../../api/zip.api';
+import { getCategoryBookstore, getHeartBookstore, searchBookstore } from '../../api/zip.api';
 import { getZipPreview } from '../../model/zip.model';
 
 export const BOOKSTORE_OPTIONS = [
@@ -33,7 +33,12 @@ const Zip = () => {
 
   useEffect(() => {
     if (isLiked) {
-      setBottomSheet(({ currentState }) => <UserLikeZip currentState={currentState} />, '내가 찜한 서점');
+      getHeartBookstore().then((data) => {
+        setBottomSheet(
+          ({ currentState }) => <UserLikeZip currentState={currentState} bookstoreList={data} />,
+          '내가 찜한 서점',
+        );
+      });
     }
     // prevView가 없다면 닫기 (돌아왔을 때만 닫힘)
     else if (!prevView && !currentBookstore && searchWord === '') {

--- a/src/pages/Zip/Zip.tsx
+++ b/src/pages/Zip/Zip.tsx
@@ -44,7 +44,7 @@ const Zip = () => {
   useEffect(() => {
     if (currentBookstore) {
       getCategoryBookstore(currentBookstore).then((data) => {
-        setLocations(data.map((store: getZipPreview) => ({ address: store.address.slice(8) })));
+        setLocations(data.map((store: getZipPreview) => ({ address: store.address })));
         setBottomSheet(
           ({ currentState }) => <SearchZip searchResults={data} currentState={currentState} />,
           '독립 서점',

--- a/src/pages/Zip/Zip.tsx
+++ b/src/pages/Zip/Zip.tsx
@@ -26,8 +26,9 @@ const Zip = () => {
   const [searchResults, setSearchResults] = useState<getZipPreview[]>([]);
   const { setBottomSheet, closeBottomSheet, isOpen } = useBottomSheetStore();
   const [prevView, setPrevView] = useState(() => useBottomSheetStore.getState().prevView || null);
+  const [locations, setLocations] = useState<{ address: string }[]>([]);
 
-  useMap(location?.latitude, location?.longitude);
+  useMap(location?.latitude, location?.longitude, locations);
   const handleCurrentLocation = useCurrentLocation(location, error);
 
   useEffect(() => {
@@ -43,6 +44,7 @@ const Zip = () => {
   useEffect(() => {
     if (currentBookstore) {
       getCategoryBookstore(currentBookstore).then((data) => {
+        setLocations(data.map((store: getZipPreview) => ({ address: store.address.slice(8) })));
         setBottomSheet(
           ({ currentState }) => <SearchZip searchResults={data} currentState={currentState} />,
           '독립 서점',

--- a/src/pages/Zip/Zip.tsx
+++ b/src/pages/Zip/Zip.tsx
@@ -80,6 +80,7 @@ const Zip = () => {
     try {
       searchBookstore(searchWord).then((data) => {
         setSearchResults(data);
+        setLocations(data.map((store: getZipPreview) => ({ address: store.address })));
 
         setBottomSheet(
           ({ currentState }) => <SearchZip searchResults={data} currentState={currentState} />,

--- a/src/utils/getLatLngFromAddress.ts
+++ b/src/utils/getLatLngFromAddress.ts
@@ -1,0 +1,26 @@
+type GeocoderAddress = {
+  address_name: string;
+  x: string;
+  y: string;
+};
+
+export const getLatLngFromAddress = (address: string): Promise<{ lat: number; lng: number }> => {
+  return new Promise((resolve, reject) => {
+    if (!window.kakao || !window.kakao.maps || !window.kakao.maps.services) {
+      reject(new Error('카카오맵 API가 로드되지 않았습니다.'));
+      return;
+    }
+
+    const geocoder = new window.kakao.maps.services.Geocoder();
+
+    geocoder.addressSearch(address, (result: GeocoderAddress[], status: string) => {
+      if (status === window.kakao.maps.services.Status.OK && result.length > 0) {
+        const lat = Number(result[0].y);
+        const lng = Number(result[0].x);
+        resolve({ lat, lng });
+      } else {
+        reject(new Error(`주소 변환 실패: ${address}`));
+      }
+    });
+  });
+};


### PR DESCRIPTION
## 🔥 Issues
#14

## ✅ What to do

- [x] 서점 리스트 마커 표시
- [x] 서점 데이터 형식 수정
- [x] 사용자가 찜한 서점 api 연동

## 📄 Description
* 서점 검색 / 카테고리 불러오면 리스트에 있는 서점들 마커 표시
* 사용자가 찜한 서점 API 연동

## 🤔 Considerations
### 마커 표시
* 마커를 표시하려면 좌표가 필요한데, 주소만 있는 상황
  * 입력된 주소를 위도(latitude), 경도(longitude) 좌표로 변환하는 함수 getLatLngFromAddress 구현
  * 카카오맵 Geocoder API를 활용하여 주소 검색 후 좌표 반환
* 마커 표시
  * 주소를 마커로 변환할 때 API 요청이 동시에 발생하여 과부하 가능성
  * 표시된 마커가 다 보이지 않음
    * API 요청 간격 100ms 추가 → 한꺼번에 요청하지 않고 순차적으로 실행
    * 지도 범위(`LatLngBounds`) 조정 → 모든 마커가 화면에 보이도록 자동 확대


## 🛠️ Improvements to Make
* 기본 필터링이 거리순이어야하는데, 아직 백에서 거리순으로 넘겨주고 있지 않아서 추후 수정이 필요
* 마커를 누르면 상세 정보 페이지로 연결해야한다

## 👀 References
<img width="343" alt="image" src="https://github.com/user-attachments/assets/64978510-84b9-403c-b076-bcb92c332eff" />



