### PR TITLE
[Feat] 로그인 api 분리 및 임시 비밀번호 확인

### DIFF
--- a/src/api/login.api.ts
+++ b/src/api/login.api.ts
@@ -1,0 +1,68 @@
+import instance from './instance';
+
+// 로그인
+export const SignIn = async (email: string, password: string) => {
+  try {
+    const response = await instance.post('/auth/signin', { email, password });
+    if (response.status == 200) {
+      return response.data;
+    }
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+// 임시 비밀번호 확인
+export const IsTempPw = async () => {
+  try {
+    const response = await instance.get(`api/temp-password`);
+    if (response.status == 200) {
+      return response.data;
+    }
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+// 회원가입
+export const SignUp = async (email: string, password: string) => {
+  try {
+    const response = await instance.post('/auth/signup', { email, password });
+    if (response.status == 200) {
+      return response;
+    }
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+// 회원가입 - 추가정보
+export const SignUpAdd = async (nickname: string) => {
+  let tempToken = localStorage.getItem('token');
+  const headers = {
+    Authorization: `${tempToken}`,
+  };
+
+  try {
+    const response = await instance.post('/auth/signup/add', { nickname }, { headers });
+
+    if (response.status === 200) {
+      localStorage.removeItem('token');
+      return response.data;
+    }
+  } catch (err) {
+    console.log(err);
+  }
+};
+
+// 비밀번호 재전송
+export const getTempPw = async (email: string) => {
+  try {
+    const response = await instance.post('api/new-password', { email: email });
+    if (response.status === 200) {
+      return response.data;
+    }
+  } catch (err) {
+    console.log(err);
+  }
+};

--- a/src/pages/FindPW/FindPw.tsx
+++ b/src/pages/FindPW/FindPw.tsx
@@ -4,21 +4,16 @@ import key from '../../../public/icons/login-signup/Key.png';
 import Button from '../../components/Button/Button';
 import InputField from '../../components/Login/InputField';
 import { useState } from 'react';
-import instance from '../../api/instance';
+import { getTempPw } from '../../api/login.api';
 
 const FindPw = () => {
   const nav = useNavigate();
   const [email, setEmail] = useState('');
 
   const handleSubmit = async () => {
-    try {
-      const response = await instance.post('api/new-password', { email: email });
-      if (response.status == 200) {
-        nav('/find-pw2');
-      }
-    } catch (error) {
-      console.log(error);
-    }
+    getTempPw(email).then((data) => {
+      nav('/login');
+    });
   };
 
   return (

--- a/src/pages/FindPW/FindPw2.tsx
+++ b/src/pages/FindPW/FindPw2.tsx
@@ -7,8 +7,6 @@ const FindPw2 = () => {
   const nav = useNavigate();
 
   const handleSubmit = () => {
-    // 이메일로 비번 전송
-    console.log('비번 전송');
     nav('/login');
   };
 

--- a/src/pages/FindPW/ResetPw.tsx
+++ b/src/pages/FindPW/ResetPw.tsx
@@ -18,7 +18,6 @@ const ResetPw = () => {
   const handleSubmit = () => {
     if (!isPwValid || !isPwMatch) return;
 
-    // 비밀번호 재설정
     console.log('비밀번호 재설정 완료');
     nav('add');
   };
@@ -62,7 +61,6 @@ const ResetPw = () => {
         <div className="h-7 w-2/5 border-b border-[#D9D9D9]"></div>
         <div className="flex flex-col items-center gap-[10px] pt-[18px] text-[12px]">
           <p className="items-center text-[#747070]">보안을 위해서 비밀번호를 재설정해주세요</p>
-          <p className="font-medium text-main_1 underline">다음에 변경하기</p>
         </div>
 
         {/* 버튼 */}

--- a/src/pages/LoginSignup/Login.tsx
+++ b/src/pages/LoginSignup/Login.tsx
@@ -3,8 +3,8 @@ import Button from '../../components/Button/Button';
 import InputField from '../../components/Login/InputField';
 import KakaoIcon from '../../../public/icons/login-signup/Kakao.svg';
 import { useNavigate } from 'react-router-dom';
-import instance from '../../api/instance';
 import { useState } from 'react';
+import { IsTempPw, SignIn } from '../../api/login.api';
 
 const Login = () => {
   const nav = useNavigate();
@@ -19,20 +19,15 @@ const Login = () => {
   };
 
   const handleLogin = async () => {
-    const payload = {
-      email: email,
-      password: password,
-    };
-
-    try {
-      const response = await instance.post('/signin', payload);
-      if (response.status == 200) {
-        console.log('성공');
-        nav('/');
-      }
-    } catch (error) {
-      console.log(error);
-    }
+    SignIn(email, password).then((data) => {
+      IsTempPw().then((data) => {
+        if (data.result == false) {
+          nav('/reset-pw');
+        } else {
+          nav('/');
+        }
+      });
+    });
   };
 
   return (

--- a/src/pages/LoginSignup/Signup.tsx
+++ b/src/pages/LoginSignup/Signup.tsx
@@ -4,6 +4,7 @@ import InputField from '../../components/Login/InputField';
 import Button from '../../components/Button/Button';
 import { useState } from 'react';
 import instance from '../../api/instance';
+import { SignUp } from '../../api/login.api';
 
 const Signup = () => {
   const nav = useNavigate();
@@ -23,22 +24,12 @@ const Signup = () => {
   const handleSubmit = async () => {
     if (!isEmailValid || !isPwValid || !isPwMatch) return;
 
-    const payload = {
-      email: email,
-      password: pw,
-    };
-
-    try {
-      const response = await instance.post('/signup', payload);
-      if (response.status == 200) {
-        let tempToken = response.headers['authorization'];
-        localStorage.setItem('token', tempToken);
-        console.log(tempToken);
-        nav('/signup/add');
-      }
-    } catch (err) {
-      console.log(err);
-    }
+    SignUp(email, pw).then((data) => {
+      let tempToken = data?.headers['authorization'];
+      localStorage.setItem('token', tempToken);
+      console.log(tempToken);
+      nav('/signup/add');
+    });
   };
 
   return (

--- a/src/pages/LoginSignup/SignupAddInfo.tsx
+++ b/src/pages/LoginSignup/SignupAddInfo.tsx
@@ -4,6 +4,7 @@ import InputField from '../../components/Login/InputField';
 import Button from '../../components/Button/Button';
 import { useState } from 'react';
 import instance from '../../api/instance';
+import { SignUpAdd } from '../../api/login.api';
 
 const SignupAddInfo = () => {
   const nav = useNavigate();
@@ -15,21 +16,9 @@ const SignupAddInfo = () => {
   const handleSubmit = async () => {
     if (!isNicknameValid) return;
 
-    let tempToken = localStorage.getItem('token');
-    const headers = {
-      Authorization: `${tempToken}`,
-    };
-
-    try {
-      const response = await instance.post('/signup/add', { nickname }, { headers });
-
-      if (response.status === 200) {
-        localStorage.removeItem('token');
-        nav('/login');
-      }
-    } catch (err) {
-      console.log(err);
-    }
+    SignUpAdd(nickname).then((data) => {
+      nav('/login');
+    });
   };
 
   return (

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -34,7 +34,6 @@ export const router = createBrowserRouter([
   { path: '/signup/add', element: <SignupAddInfo /> },
   { path: '/find-pw', element: <FindPw /> },
   { path: '/find-pw2', element: <FindPw2 /> },
-  { path: '/reset-pw', element: <ResetPw /> },
   { path: '/bookie', element: <Bookie /> },
   {
     path: 'zip/create-review',
@@ -60,4 +59,5 @@ export const router = createBrowserRouter([
       </ProtectedRoute>
     ),
   },
+  { path: '/reset-pw', element: <ResetPw /> },
 ]);


### PR DESCRIPTION
## 🔥 Issues
#12 

## ✅ What to do
- [x] 로그인 api 분리
- [x] 로그인 시 임시비밀번호인지 확인

## 📄 Description
* 로그인 성공 시, 임시 비밀번호 여부를 확인하는 API 요청 추가
  * 결과에 따라 임시 비밀번호일 경우 → 비밀번호 변경 페이지로 이동,
  * 일반 비밀번호일 경우 → 메인 홈으로 이동

## 🤔 Considerations
* 모든 경우 홈 페이지로 이동 후, navigate의 state를 이용해 임시 비밀번호 여부를 판단하고 모달을 띄우는 방식을 고민
  * 하지만 임시 비밀번호 변경은 디자인 상 모달보다 별도 페이지가 더 적합하다고 판단
  * 따라서 모달 대신 비밀번호 변경 페이지로 직접 이동하는 방식으로 수정

## 🛠️ Improvements to Make
* 확실하진 않은데 지금 상태코드가 200이 아니여도 return 되는 것 같다. 나중에 확인 후 수정 필요

## 👀 References
<img width="345" alt="image" src="https://github.com/user-attachments/assets/935dec02-55dd-4417-9872-6ab5b924ecd2" />
