### PR TITLE
[Fix] Booksnap 피드 오류 수정

### DIFF
--- a/src/pages/Booksnap/BookSnap.tsx
+++ b/src/pages/Booksnap/BookSnap.tsx
@@ -9,7 +9,7 @@ import { getReview } from '../../api/booksnap.api';
 const BookSnap = () => {
   const [filter, setFilter] = useState<FilterType>('createdAt');
   const [review, setReview] = useState<BooksnapPreview[]>([]);
-  const [page, setPage] = useState(0);
+  const [page, setPage] = useState(1);
   const [isLast, setIsLast] = useState<boolean>(false);
   const [isBottom, setIsBottom] = useState<boolean>(false);
   const mainRef = useRef<HTMLDivElement>(null);

--- a/src/pages/Booksnap/BookSnap.tsx
+++ b/src/pages/Booksnap/BookSnap.tsx
@@ -15,31 +15,54 @@ const BookSnap = () => {
   const mainRef = useRef<HTMLDivElement>(null);
   const isLastRef = useRef<boolean>(false);
 
-  const getReviews = () => {
-    return getReview(filter, page).then((data) => {
-      setReview((prev) => (prev ? [...prev, ...data.data.booksnapPreview] : data.data.booksnapPreview));
+  // 리뷰 목록 받아오기
+  const getReviews = async () => {
+    try {
+      const data = await getReview(filter, page);
+      setReview((prev) => (page === 1 ? data.data.booksnapPreview : [...prev, ...data.data.booksnapPreview]));
       setIsLast(data.data.last);
-    });
+      setIsBottom(false);
+    } catch (error) {
+      console.error('리뷰를 불러오는 중 에러 발생:', error);
+    }
   };
 
+  // filter가 변경될 때 상태 초기화 및 getReviews 호출
+  useEffect(() => {
+    setReview([]);
+    setIsLast(false);
+    setIsBottom(false);
+
+    if (page !== 1) {
+      setPage(1); // page가 1이 아니면 1로 초기화 (getReviews는 page가 바뀔 때 호출됨)
+    } else {
+      getReviews(); // page가 1이면 바로 getReviews 호출
+    }
+  }, [filter]);
+
+  // page가 변경될 때만 getReviews 호출
+  useEffect(() => {
+    if (page !== 1 || review.length === 0) {
+      // 🔄 리뷰가 없거나 페이지가 1이 아닐 때만 호출
+      getReviews();
+    }
+  }, [page]);
+
+  // isLast 업데이트 시 참조 업데이트
   useEffect(() => {
     isLastRef.current = isLast;
   }, [isLast]);
 
-  useEffect(() => {
-    setPage(0);
-    setReview([]);
-    setIsLast(false);
-  }, [filter]);
-
+  // 바닥 감지
   const detectBottom = () => {
     if (mainRef.current) {
       const { scrollTop, clientHeight, scrollHeight } = mainRef.current;
-      return scrollTop + clientHeight >= scrollHeight - 1;
+      return scrollHeight > clientHeight && scrollTop + clientHeight >= scrollHeight - 1;
     }
     return false;
   };
 
+  // 스크롤이 바닥에 있고, 마지막 페이지가 아니면 page + 1
   const handleScrollEvent = () => {
     if (detectBottom() && !isBottom && !isLastRef.current) {
       setIsBottom(true);
@@ -47,6 +70,7 @@ const BookSnap = () => {
     }
   };
 
+  // 스크롤 이벤트 등록
   useEffect(() => {
     if (mainRef.current) {
       mainRef.current.addEventListener('scroll', handleScrollEvent);
@@ -55,10 +79,6 @@ const BookSnap = () => {
       };
     }
   }, []);
-
-  useEffect(() => {
-    getReviews().then(() => setIsBottom(false));
-  }, [page]);
 
   if (!review) {
     return <Loading text="데이터를 불러오는 데 실패했습니다!" />;


### PR DESCRIPTION
## 🔥 Issues
#33 

## ✅ What to do

- [x] Booksnap 피드 오류 수정

## 📄 Description
* 필터별로 북스냅 리뷰 보여주기
* 스크롤이 하단에 닿으면 다음 페이지 자동 요청

## 🤔 Considerations
### 📌 Page가 1일 때, 필터 변경 시 요청이 가지 않는 문제 해결
* filter가 변경되면 page를 1로 변경하도록 했으나, 이미 page가 1인 상태에서는 getReviews가 호출되지 않는 문제 발생.
  * filter가 변경될 때 page가 1이면 즉시 getReviews 호출.
  * page가 1이 아니면 page를 1로 설정하고 그 후에 getReviews 호출.
### 📌 필터 변경 시 중복 요청 문제 해결
* page가 2 이상일 때 filter를 변경하면 page=1과 page=2로 중복 요청 발생.
* 알고보니 filter 변경 시 setReview([])로 인해 리뷰가 비워짐. 이로 인해 scrollHeight와 clientHeight가 비슷해짐. detectBottom 조건 (scrollTop + clientHeight >= scrollHeight - 1)이 즉시 true가 되어 스크롤이 바닥으로 감지됨.
  * detectBottom 조건에 scrollTop + clientHeight > scrollHeight 조건 추가해 중복 요청 방지.

## 🛠️ Improvements to Make
개선할 점

## 👀 References

스크린샷 또는 참고사항
