### PR TITLE
[Fix] vite.config 파일 base 경로 수정

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,10 +4,5 @@ import svgr from 'vite-plugin-svgr';
 
 // https://vite.dev/config/
 export default defineConfig({
-  base: './',
-  build: {
-    outDir: 'dist',
-    assetsDir: 'assets', // ✅ CSS, JS, 이미지 파일이 `dist/assets/`에 저장됨
-  },
   plugins: [react(), svgr()],
 });


### PR DESCRIPTION
## 🔥 Issues

이슈 연결

## ✅ What to do

- [x] vite.config 파일 base 경로 수정

## 📄 Description
* vite.config 파일 base 경로 `./`를 삭제

## 🤔 Considerations
* 저번에 css가 적용 안되는 문제가 생겼을 때, vite.config 파일 base 경로 `./`를 추가했었는데, 알고보니 cloudFront의 cache 문제였음
* 그리고 배포 사이트에서 카카오 로그인할 때 경로 에러가 발생하여서 base를 다시 삭제(기본 base는 `/`)해 해결

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

스크린샷 또는 참고사항
