### PR TITLE
[Fix] 토스트 라이브러리로 수정 및 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "leva": "^0.9.35",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-hot-toast": "^2.5.2",
         "react-icons": "^5.4.0",
         "react-router-dom": "^7.0.1",
         "tailwind-scrollbar": "^3.1.0",
@@ -4005,6 +4006,14 @@
       "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
       "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w=="
     },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -5278,6 +5287,22 @@
       },
       "peerDependencies": {
         "react": ">= 16.8"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.5.2.tgz",
+      "integrity": "sha512-Tun3BbCxzmXXM7C+NI4qiv6lT0uwGh4oAfeJyNOjYUejTsm35mK9iCaYLGv8cBz9L5YxZLx/2ii7zsIwPtPUdw==",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-icons": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "leva": "^0.9.35",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-hot-toast": "^2.5.2",
     "react-icons": "^5.4.0",
     "react-router-dom": "^7.0.1",
     "tailwind-scrollbar": "^3.1.0",

--- a/src/components/Booksnap/ReviewPreview.tsx
+++ b/src/components/Booksnap/ReviewPreview.tsx
@@ -2,18 +2,16 @@ import { FaStar } from 'react-icons/fa';
 import { BooksnapPreview } from '../../model/booksnap.model';
 import { timeAgo } from '../../utils/timeDifference';
 import { IoMdThumbsUp } from 'react-icons/io';
-import ButtonShort from '../Button/ButtonShort';
 import { useEffect, useState } from 'react';
 import { deleteLike, pickBook, postLike } from '../../api/booksnap.api';
 import { MdBookmarkAdd } from 'react-icons/md';
+import toast from 'react-hot-toast';
 
 interface ReviewPreviewProps {
   review: BooksnapPreview;
-  setToast: React.Dispatch<React.SetStateAction<boolean>>;
-  setTitle: React.Dispatch<React.SetStateAction<string>>;
 }
 
-const ReviewPreview = ({ review, setToast, setTitle }: ReviewPreviewProps) => {
+const ReviewPreview = ({ review }: ReviewPreviewProps) => {
   const [isLiked, setIsLiked] = useState<boolean>(review.isLiked);
   const [likeCount, setLikeCount] = useState<number>(review.like);
 
@@ -24,33 +22,39 @@ const ReviewPreview = ({ review, setToast, setTitle }: ReviewPreviewProps) => {
 
   // 좋아요 관리
   const handleLike = () => {
-    const newLike = !isLiked;
-    setLikeCount((prev) => (newLike ? +prev + 1 : +prev - 1));
-    setIsLiked(newLike);
-
-    // 좋아요 api 요청
-    if (newLike) {
-      postLike(review.bookReviewId).then((data) => {
-        console.log('좋아요 성공');
-      });
+    if (!localStorage.getItem('accessToken')) {
+      toast.error('로그인이 필요한 서비스입니다.');
     } else {
-      deleteLike(review.bookReviewId).then((data) => {
-        console.log('좋아요 취소 성공');
-      });
+      const newLike = !isLiked;
+      setLikeCount((prev) => (newLike ? +prev + 1 : +prev - 1));
+      setIsLiked(newLike);
+
+      // 좋아요 api 요청
+      if (newLike) {
+        postLike(review.bookReviewId).then((data) => {
+          console.log('좋아요 성공');
+        });
+      } else {
+        deleteLike(review.bookReviewId).then((data) => {
+          console.log('좋아요 취소 성공');
+        });
+      }
     }
   };
 
   // 책 담기
   const handlePickBook = () => {
-    pickBook(review.bookInfo.isbn).then((data) => {
-      if (data?.success) {
-        setToast(true);
-        setTitle(`${review.bookInfo.title}을(를) 책장에 담았어요!`);
-      } else {
-        setToast(true);
-        setTitle(data?.message || '책 담기에 실패했습니다.');
-      }
-    });
+    if (!localStorage.getItem('accessToken')) {
+      toast.error('로그인이 필요한 서비스입니다.');
+    } else {
+      pickBook(review.bookInfo.isbn).then((data) => {
+        if (data?.success) {
+          toast.success(`${review.bookInfo.title}을(를) 책장에 담았어요!`);
+        } else {
+          toast.error(`${data?.message}`);
+        }
+      });
+    }
   };
 
   return (
@@ -96,8 +100,8 @@ const ReviewPreview = ({ review, setToast, setTitle }: ReviewPreviewProps) => {
           <p>담기</p>
         </div>
         <div className="border-x-[0.5px] border-gray_3"></div>
-        <div className="flex flex-1 items-center justify-center gap-1" onClick={handleLike}>
-          <IoMdThumbsUp className={`h-4 w-4 ${isLiked ? 'fill-main_1' : ''}`} />
+        <div className="flex flex-1 items-center justify-center gap-1">
+          <IoMdThumbsUp className={`h-4 w-4 ${isLiked ? 'fill-main_1' : ''}`} onClick={handleLike} />
           <p>좋아요</p>
           <p>{likeCount}</p>
         </div>

--- a/src/components/Common/Toast.tsx
+++ b/src/components/Common/Toast.tsx
@@ -1,26 +1,7 @@
-import { useEffect } from 'react';
-import Check from '../../../public/icons/book-snap/check.svg?react';
+import { Toaster } from 'react-hot-toast';
 
-type ToastProps = {
-  setToast: React.Dispatch<React.SetStateAction<boolean>>;
-  title: string;
-};
-
-const Toast = ({ setToast, title }: ToastProps) => {
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setToast(false);
-    }, 2000);
-
-    return () => clearTimeout(timer);
-  }, [setToast]);
-
-  return (
-    <div className="animate-fade-in-out fixed left-1/2 top-4 z-50 flex w-[80%] -translate-x-1/2 items-center rounded-lg bg-white px-4 py-2 text-base font-semibold shadow-lg">
-      <Check className="mr-2 h-[18px] w-[18px]" />
-      <span>{title}</span>
-    </div>
-  );
+const Toast = () => {
+  return <Toaster position="top-center" reverseOrder={false} />;
 };
 
 export default Toast;

--- a/src/pages/Booksnap/BookSnap.tsx
+++ b/src/pages/Booksnap/BookSnap.tsx
@@ -15,8 +15,6 @@ const BookSnap = () => {
   const [isBottom, setIsBottom] = useState<boolean>(false);
   const mainRef = useRef<HTMLDivElement>(null);
   const isLastRef = useRef<boolean>(false);
-  const [toast, setToast] = useState(false);
-  const [title, setTitle] = useState('');
 
   // 리뷰 목록 받아오기
   const getReviews = async () => {
@@ -93,12 +91,12 @@ const BookSnap = () => {
         <FilterBar filter={filter} setFilter={setFilter} />
         <div className="mt-8 flex flex-col gap-6 px-8 py-8">
           {review.map((preview, index) => (
-            <ReviewPreview review={preview} key={index} setToast={setToast} setTitle={setTitle} />
+            <ReviewPreview review={preview} key={index} />
           ))}
         </div>
         <WriteButton />
       </div>
-      {toast && <Toast title={title} setToast={setToast} />}
+      <Toast />
     </div>
   );
 };


### PR DESCRIPTION
## 🔥 Issues
#33 

## ✅ What to do

- [x] 토스트 라이브러리로 수정(react-hot-toast)
- [x] 북스냅에 토스트 적용

## 📄 Description
* 책담기
  * 로그인 안한 경우 -> '로그인이 필요한 서비스입니다' 토스트
  * 로그인 한 경우 -> '책 제목'을(를) 책장에 담았습니다' 토스트
  * 이미 담긴 책일 경우 -> '이미 담긴 책입니다' 토스트
* 좋아요
  *  로그인 안한 경우 -> '로그인이 필요한 서비스입니다' 토스트

## 🤔 Considerations
### Toast 수정
#### 문제점
- 기존에 `setToast`를 사용하여 `toast`가 `true`일 때 `type`과 `text`를 받아 토스트를 띄우는 방식을 생각.
- 이 방식은 여러 `props`를 전달해야 하며, 한 번 실행된 후 토스트가 두 번씩 중복으로 나타나는 문제가 발생.

#### 해결 방법
- `setToast`, `type`, `text` 상태를 제거하고, `toast()`를 직접 호출하는 방식으로 변경.
- `BookSnap` 피드에는 `<Toaster />`만 남겨두고, `ReviewPreview` 내부에서 `toast.success('성공')`처럼 직접 호출하도록 수정.
- 불필요한 `props` 전달을 줄이고, 중복 실행 문제를 해결하여 코드 구조를 간결하게 정리.

## 🛠️ Improvements to Make
* 현재는 책 담기과 좋아요 버튼을 눌럿을 때 각각 로그인 여부를 확인해 toast를 호춣하는데, 로직을 하나로 합쳐도 좋을듯.

## 👀 References
<img width="339" alt="Screenshot 2025-03-09 at 1 04 08 AM" src="https://github.com/user-attachments/assets/b9b7302f-6786-4a19-94a9-ca6d6d211792" />
<img width="339" alt="Screenshot 2025-03-09 at 1 04 08 AM" src="https://github.com/user-attachments/assets/bca93696-61a0-4fac-b99d-f1d6850231df" />
<img width="339" alt="Screenshot 2025-03-09 at 1 04 08 AM" src="https://github.com/user-attachments/assets/e3f7e570-1744-40ba-be0b-270c62a515e5" />


