### PR TITLE
[Fix] reissue와 search(zip) 사소한 오류들 수정

### DIFF
--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -9,55 +9,59 @@ const instance = axios.create({
   },
 });
 
+// 요청 인터셉터
 instance.interceptors.request.use(
   (config) => {
-    // 요청이 전달되기 전 헤더에 토큰 추가
     const accessToken = localStorage.getItem('accessToken');
     if (accessToken) {
       config.headers.Authorization = `Bearer ${accessToken}`;
     }
     return config;
   },
-  (error) => {
-    return Promise.reject(error);
-  },
+  (error) => Promise.reject(error),
 );
 
+// 응답 인터셉터
 instance.interceptors.response.use(
   (response) => {
-    if (response.data.data?.accessToken && response.data.data?.refreshToken) {
-      localStorage.setItem('accessToken', response.data.data.accessToken);
-      localStorage.setItem('refreshToken', response.data.data.refreshToken);
+    const { accessToken, refreshToken } = response.data.data || {};
+    if (accessToken && refreshToken) {
+      localStorage.setItem('accessToken', accessToken);
+      localStorage.setItem('refreshToken', refreshToken);
     }
     return response;
   },
   async (error) => {
-    const refreshToken = localStorage.getItem('refreshToken');
+    const originalRequest = error.config;
 
-    // 토큰 재발급
-    if (error.response.status === 401) {
+    // reissue 요청 자체는 재시도하지 않음
+    if (originalRequest.url.includes('auth/reissue')) {
+      return Promise.reject(error);
+    }
+
+    // 무한 루프 방지를 위한 플래그
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+
       try {
-        const res = await axios.post(`http://api.bookstore-zip.site/auth/reissue`, {
-          refreshToken: refreshToken,
-        });
-        if (res.status == 200) {
-          const { accessToken, refreshToken } = res.data.data;
-          localStorage.setItem('accessToken', accessToken);
-          localStorage.setItem('refreshToken', refreshToken);
-        }
+        const refreshToken = localStorage.getItem('refreshToken');
+        const res = await instance.post('auth/reissue', { refreshToken });
 
-        // 새 토큰으로 헤더 업데이트 후 재요청
-        error.config.headers.Authorization = `Bearer ${res.data.data.accessToken}`;
-        return axios(error.config);
+        const { accessToken, refreshToken: newRefreshToken } = res.data.data;
+        localStorage.setItem('accessToken', accessToken);
+        localStorage.setItem('refreshToken', newRefreshToken);
+
+        originalRequest.headers.Authorization = `Bearer ${accessToken}`;
+        return instance(originalRequest);
       } catch (refreshErr) {
-        console.log('Token 갱신 실패: ', refreshErr);
-
+        console.log('Token 갱신 실패:', refreshErr);
         localStorage.removeItem('accessToken');
         localStorage.removeItem('refreshToken');
-
         window.location.href = '/login';
+        return Promise.reject(refreshErr);
       }
     }
+
     return Promise.reject(error);
   },
 );

--- a/src/components/BottomSheet/BottomSheet.tsx
+++ b/src/components/BottomSheet/BottomSheet.tsx
@@ -26,7 +26,7 @@ function BottomSheet() {
       ) : (
         <Header />
       )}
-      <div className="overflow-auto overscroll-contain scrollbar-hide" ref={content}>
+      <div className="overflow-y-auto overscroll-contain scrollbar-hide" ref={content}>
         {view ? view({ currentState }) : null}
       </div>
     </div>

--- a/src/components/Header/HomeHeader.tsx
+++ b/src/components/Header/HomeHeader.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import Logo from '../../../public/icons/menu-bar/logo.svg?react';
 import SearchBar from '../Zip/SearchBar';
+import { useNavigate } from 'react-router-dom';
 
 interface HomeHeaderProps {
   onSearch: () => void;
@@ -9,9 +10,11 @@ interface HomeHeaderProps {
 }
 
 const HomeHeader = ({ onSearch, setSearchWord, searchWord }: HomeHeaderProps) => {
+  const nav = useNavigate();
+
   return (
     <div className="fixed left-0 right-0 top-0 z-20 m-auto flex max-w-[500px] items-center gap-[15px] border-b-[1px] border-[#544F4F] bg-bg py-[10px] pl-[30px] pr-[30px]">
-      <Logo className="h-[30px] w-6" />
+      <Logo className="h-[30px] w-6" onClick={() => nav('/')} />
       <SearchBar
         searchWord={searchWord}
         setSearchWord={setSearchWord}

--- a/src/components/Zip/ZipPreview.tsx
+++ b/src/components/Zip/ZipPreview.tsx
@@ -6,6 +6,7 @@ import { getZipPreview } from '../../model/zip.model';
 import { BOOKSTORE_OPTIONS } from '../../pages/Zip/Zip';
 import { useState } from 'react';
 import { likeZip } from '../../api/zip.api';
+import toast from 'react-hot-toast';
 
 interface ZipPreviewProps {
   bookstore: getZipPreview;
@@ -23,6 +24,11 @@ const ZipPreview = ({ bookstore, index }: ZipPreviewProps) => {
   const handleLike = (e: React.MouseEvent<HTMLOrSVGElement>) => {
     e.preventDefault();
     e.stopPropagation();
+
+    if (!localStorage.getItem('accessToken')) {
+      toast.error('로그인이 필요한 서비스입니다.');
+      return;
+    }
 
     const newLike = !isLiked;
     setIsLiked(newLike);

--- a/src/hooks/useBottomSheet.ts
+++ b/src/hooks/useBottomSheet.ts
@@ -107,6 +107,8 @@ export default function useBottomSheet() {
       return true;
     };
 
+    if (!sheet.current || !content.current) return;
+
     const handleTouchStart = (e: TouchEvent) => {
       const { touchStart } = metrics.current;
       touchStart.sheetY = sheet.current!.getBoundingClientRect().y;
@@ -194,12 +196,12 @@ export default function useBottomSheet() {
           if (isMovingDown) {
             sheet.current!.style.setProperty('transform', `translateY(64px)`); // 중간 -> 최소
             setCurrentState('close');
-            console.log(currentHeight);
+            console.log('close');
+            closeBottomSheet();
           } else if (isMovingUp) {
             sheet.current!.style.setProperty('transform', `translateY(${MID_Y - MAX_Y}px)`); // 최소 -> 중간
             setCurrentState('mid');
             setCurrentHeight(BOTTOM_SHEET_HEIGHT_MID);
-            console.log(currentHeight);
           }
         }
       }
@@ -218,14 +220,22 @@ export default function useBottomSheet() {
       };
     };
 
-    sheet.current!.addEventListener('touchstart', handleTouchStart);
-    sheet.current!.addEventListener('touchend', handleTouchEnd);
-    sheet.current!.addEventListener('touchmove', handleTouchMove, {
+    sheet.current.addEventListener('touchstart', handleTouchStart);
+    sheet.current.addEventListener('touchend', handleTouchEnd);
+    sheet.current.addEventListener('touchmove', handleTouchMove, {
       passive: false,
     });
+
+    // return () => {
+    //   sheet.current?.removeEventListener('touchstart', handleTouchStart);
+    //   sheet.current?.removeEventListener('touchmove', handleTouchMove);
+    //   sheet.current?.removeEventListener('touchend', handleTouchEnd);
+    // };
   }, []);
 
   useEffect(() => {
+    if (!content.current) return;
+
     const handleTouchStart = () => {
       metrics.current!.isContentAreaTouched = true;
     };

--- a/src/pages/Zip/Zip.tsx
+++ b/src/pages/Zip/Zip.tsx
@@ -11,6 +11,8 @@ import { getHeartBookstore, searchBookstore } from '../../api/zip.api';
 import { getZipPreview } from '../../model/zip.model';
 import HomeHeader from '../../components/Header/HomeHeader';
 import { useLocation } from 'react-router-dom';
+import toast, { Toaster } from 'react-hot-toast';
+import useBottomSheet from '../../hooks/useBottomSheet';
 
 export const BOOKSTORE_OPTIONS = [
   { key: 'INDEP', label: '📚 독립서점' },
@@ -25,10 +27,10 @@ const Zip = () => {
   const { setBottomSheet, closeBottomSheet, isOpen, resultCount } = useBottomSheetStore();
   const [prevView, setPrevView] = useState(() => useBottomSheetStore.getState().prevView || null);
   const [locations, setLocations] = useState<{ address: string }[]>([]);
+  const { setCurrentState } = useBottomSheet();
 
   const locationState = useLocation();
-  const initialSearchWord = locationState.state?.searchWord || '';
-  const [searchWord, setSearchWord] = useState<string>(initialSearchWord);
+  const [searchWord, setSearchWord] = useState<string>('');
 
   useMap(location?.latitude, location?.longitude, locations);
   const handleCurrentLocation = useCurrentLocation(location);
@@ -52,14 +54,22 @@ const Zip = () => {
   }, [isLiked, prevView]);
 
   useEffect(() => {
-    if (initialSearchWord) {
-      handleSearch(); // 최초 진입 시 검색어가 있으면 자동 검색 실행
+    if (locationState.state?.searchWord) {
+      setSearchWord(locationState.state.searchWord);
+      handleSearch();
+      window.history.replaceState({}, '', locationState.pathname);
+    } else {
+      setSearchWord('');
     }
-  }, [initialSearchWord]);
+  }, [locationState.state]);
 
   // 좋아요 처리
   const handleHeart = () => {
-    setIsLiked((prev) => !prev);
+    if (localStorage.getItem('accessToken')) {
+      setIsLiked((prev) => !prev);
+    } else {
+      toast.error('로그인이 필요한 서비스입니다.');
+    }
   };
 
   // 현위치 처리
@@ -79,6 +89,7 @@ const Zip = () => {
       // 정상 처리
       setSearchResults(data);
       setLocations(data.data.slice(0, 10).map((store: any) => ({ address: store.address })));
+      setCurrentState('mid');
       setBottomSheet(
         ({ currentState }) => <SearchZip searchResults={data.data} currentState={currentState} />,
         'ZIP 검색 결과',
@@ -113,6 +124,7 @@ const Zip = () => {
       </div>
       <div id="map" className="h-full w-full" />
       <BottomSheet />
+      <Toaster />
     </div>
   );
 };


### PR DESCRIPTION
## 🔥 Issues

이슈 연결

## ✅ What to do

- [x] reissue 오류 해결
- [x] 로고 누르면 home으로 이동
- [x] 로그인 안된 상태면 토스트 띄우기
- [x] 새로고침 시 검색상태 초기화

## 📄 Description
* reissue의 baseURL이 http로 설정되어있어서, mixed contents 에러가 발생한거였음.
  * instance를 사용해 상대경로로 수정해주었다.
* 로고 누르면 home으로 이동하도록 수정
* 로그인 안된 상태에서 '내가 찜한 서점 보기'나 '서점 찜하기' 버튼을 누르면 로그인 창으로 이동했음
  * '로그인이 필요한 서비스입니다' 토스트를 띄우게 변경
* search 페이지나 home에서 검색을 하면 zip 페이지로 state를 가지고 자동으로 이동하게 되는데, 새로고침을 해도 검색결과가 유지됨
  * state를 삭제하는 로직 작성

## 🤔 Considerations
### 검색 결과 관련 문제
- Search 페이지나 Home에서 검색하면 Zip 페이지로 `state`를 전달하며 자동 이동하게 했음
- 그러나 새로고침해도 이전 검색 결과가 계속 유지되는 문제가 발생함

#### 원인
- 초기 렌더링 시 `location.state?.searchWord`를 `useState`의 초기값으로 설정하고 있어서  
  새로고침 후에도 `searchWord`가 그대로 남아있었음

#### 해결
- `useEffect`에서 `location.state?.searchWord`가 존재하면:
  - `setSearchWord()`로 검색어를 설정한 후
  - `window.history.replaceState()`를 통해 `state`를 제거함
- 반대로 `location.state`가 없으면 `setSearchWord('')`로 상태 초기화하여 검색 결과를 지움


## 🛠️ Improvements to Make
* 생각해보니까 검색은 주로 쿼리스트링을 사용해서... 사실 넘길 때 state말고 쿼리를 사용하게 했으면 됐을 것 같은데... 생각해보고 수정하든지 해야할 것 같다.

## 👀 References

스크린샷 또는 참고사항
