### PR TITLE
[Fix] 서점 상세 UI 수정

### DIFF
--- a/src/components/Booksnap/NoResult.tsx
+++ b/src/components/Booksnap/NoResult.tsx
@@ -2,16 +2,19 @@ import { useNavigate } from 'react-router-dom';
 
 interface NoResultProps {
   text: string;
+  color?: string;
 }
 
-const NoResult = ({ text }: NoResultProps) => {
+const NoResult = ({ text, color }: NoResultProps) => {
   const nav = useNavigate();
 
   return (
     <div className="flex flex-col items-center gap-5 p-10">
-      <div className="bg-pink flex h-20 w-20 items-center justify-center rounded-full text-heading4 font-bold">?</div>
+      <div className={`bg-${color} flex h-20 w-20 items-center justify-center rounded-full text-heading4 font-bold`}>
+        ?
+      </div>
       <div className="flex flex-col items-center gap-2">
-        <p className="text-pink text-body1 font-bold">검색 결과가 없어요!</p>
+        <p className={`text-yellow text-body1 font-bold`}>검색 결과가 없어요!</p>
         <p className="cursor-pointer text-body4 font-light text-white" onClick={() => nav('/booksnap/create/book')}>
           {text}
         </p>

--- a/src/components/Booksnap/NoResult.tsx
+++ b/src/components/Booksnap/NoResult.tsx
@@ -1,6 +1,10 @@
 import { useNavigate } from 'react-router-dom';
 
-const NoResult = () => {
+interface NoResultProps {
+  text: string;
+}
+
+const NoResult = ({ text }: NoResultProps) => {
   const nav = useNavigate();
 
   return (
@@ -9,7 +13,7 @@ const NoResult = () => {
       <div className="flex flex-col items-center gap-2">
         <p className="text-pink text-body1 font-bold">검색 결과가 없어요!</p>
         <p className="cursor-pointer text-body4 font-light text-white" onClick={() => nav('/booksnap/create/book')}>
-          출판물 등록하고 리뷰 쓰러 가기 &gt;
+          {text}
         </p>
       </div>
     </div>

--- a/src/components/BottomSheet/MaxHeader.tsx
+++ b/src/components/BottomSheet/MaxHeader.tsx
@@ -21,10 +21,12 @@ const MaxHeader = ({ closeBottomSheet, viewName, resultCount }: HeaderProps) => 
         ) : (
           <div className="text-white">{viewName}</div>
         )}
-        <div className="flex items-center gap-[2px]">
-          <FmdGoodIcon sx={{ fontSize: 14, fill: '#CFCCD4' }} />
-          <p className="text-[12px] leading-6 text-[#CFCCD4]">{resultCount}개</p>
-        </div>
+        {viewName !== '서점 상세 정보' && (
+          <div className="flex items-center gap-[2px]">
+            <FmdGoodIcon sx={{ fontSize: 14, fill: '#CFCCD4' }} />
+            <p className="text-[12px] leading-6 text-[#CFCCD4]">{resultCount}개</p>
+          </div>
+        )}
       </div>
       <div className="w-11" />
     </div>

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -8,6 +8,7 @@ const Button = ({ text, onClick, color = 'mint' }: ButtonProps) => {
   const colorMap: Record<string, string> = {
     pink: '#DEBBCC',
     mint: '#91AAA4',
+    green: '#C1D201',
   };
 
   const iconColor = colorMap[color] ?? '#CCCCCC';

--- a/src/components/Button/ButtonShort.tsx
+++ b/src/components/Button/ButtonShort.tsx
@@ -29,7 +29,7 @@ const ButtonShort = ({ type, onClick }: ButtonShortProps) => {
       case BUTTON_TYPE.REVIEW:
         setButtonType({
           buttonText: '리뷰 쓰기',
-          icon: <HiPencil className="fill-white" />,
+          icon: <HiPencil className="fill-bg" />,
         });
         break;
       case BUTTON_TYPE.ADD:
@@ -40,9 +40,12 @@ const ButtonShort = ({ type, onClick }: ButtonShortProps) => {
     }
   }, []);
   return (
-    <div className="flex h-[26px] items-center gap-[6px] rounded-[10px] bg-main_1 px-[10px] py-[6px]" onClick={onClick}>
+    <div
+      className="flex h-[26px] items-center gap-[6px] rounded-[10px] bg-orange px-[10px] py-[6px] text-bg"
+      onClick={onClick}
+    >
       {buttonType.icon}
-      <p className="text-[13px] font-normal tracking-normal text-main_2">{buttonType.buttonText}</p>
+      <p className="text-[13px] font-normal tracking-normal text-bg">{buttonType.buttonText}</p>
     </div>
   );
 };

--- a/src/components/Common/FilterBar.tsx
+++ b/src/components/Common/FilterBar.tsx
@@ -16,7 +16,7 @@ const FilterBar = ({ first, second, onChange }: FilterProps) => {
   return (
     <div className="flex w-full justify-around rounded-[20px] border-[1px] border-solid border-white bg-bg text-[11px] font-semibold text-white">
       <div
-        className={`w-full cursor-pointer rounded-l-[20px] py-[5px] text-center ${
+        className={`w-full cursor-pointer rounded-l-[20px] py-[5px] text-center leading-4 ${
           isSelected === first ? 'bg-pink text-black' : 'text-white'
         }`}
         onClick={() => setIsSelected(first)}
@@ -25,7 +25,7 @@ const FilterBar = ({ first, second, onChange }: FilterProps) => {
       </div>
       <div className="w-[1px] bg-white" />
       <div
-        className={`w-full cursor-pointer rounded-r-[20px] py-[5px] text-center ${
+        className={`w-full cursor-pointer rounded-r-[20px] py-[5px] text-center leading-4 ${
           isSelected === second ? 'bg-pink text-black' : 'text-white'
         }`}
         onClick={() => setIsSelected(second)}

--- a/src/components/Common/FilterBar.tsx
+++ b/src/components/Common/FilterBar.tsx
@@ -4,30 +4,37 @@ interface FilterProps {
   first: string;
   second: string;
   onChange: (selected: string) => void;
+  color?: string; // Tailwind 색상 클래스: ex) 'bg-yellow'
 }
 
-const FilterBar = ({ first, second, onChange }: FilterProps) => {
-  const [isSelected, setIsSelected] = useState(first); // 기본값을 first로
+const FilterBar = ({ first, second, onChange, color = 'bg-yellow' }: FilterProps) => {
+  const [isSelected, setIsSelected] = useState(first);
 
   useEffect(() => {
     onChange(isSelected);
   }, [isSelected]);
 
   return (
-    <div className="flex w-full justify-around rounded-[20px] border-[1px] border-solid border-white bg-bg text-[11px] font-semibold text-white">
+    <div className="flex w-full overflow-hidden rounded-[20px] text-[11px] font-semibold">
+      {/* 왼쪽 탭 */}
       <div
         className={`w-full cursor-pointer rounded-l-[20px] py-[5px] text-center leading-4 ${
-          isSelected === first ? 'bg-pink text-black' : 'text-white'
-        }`}
+          isSelected === first
+            ? `${color} border text-black border-${color.replace('bg-', '')} border-r-0`
+            : 'border border-r-0 border-white bg-bg text-white'
+        } `}
         onClick={() => setIsSelected(first)}
       >
         {first}
       </div>
-      <div className="w-[1px] bg-white" />
+
+      {/* 오른쪽 탭 */}
       <div
         className={`w-full cursor-pointer rounded-r-[20px] py-[5px] text-center leading-4 ${
-          isSelected === second ? 'bg-pink text-black' : 'text-white'
-        }`}
+          isSelected === second
+            ? `${color} border text-black border-${color.replace('bg-', '')} border-l-0`
+            : 'border border-l-0 border-white bg-bg text-white'
+        } `}
         onClick={() => setIsSelected(second)}
       >
         {second}

--- a/src/components/Zip/SearchBar.tsx
+++ b/src/components/Zip/SearchBar.tsx
@@ -21,7 +21,7 @@ const SearchBar = ({ setSearchWord, searchWord, onSearch, text }: SearchBarProps
       <IoSearch className="absolute left-3 top-1/2 h-[16px] w-[16px] -translate-y-1/2 text-[#C6B8B8]" />
       <input
         placeholder={text}
-        className="w-full rounded-[12px] bg-bg_2 py-[5px] pl-[38px] text-[14px] text-[#C6B8B8] focus:outline-none focus:ring-1 focus:ring-white"
+        className="w-full rounded-[20px] bg-bg_2 py-[5px] pl-[38px] text-[14px] text-[#C6B8B8] focus:outline-none focus:ring-1 focus:ring-white"
         onChange={(e) => setSearchWord(e.target.value)}
         value={searchWord}
         onKeyDown={handleEnter}

--- a/src/components/Zip/Star.tsx
+++ b/src/components/Zip/Star.tsx
@@ -4,15 +4,16 @@ interface StarProps {
   rating: number;
   setRating: (value: number) => void;
   size: number;
+  color?: string;
 }
 
-const Star = ({ rating, setRating, size }: StarProps) => {
+const Star = ({ rating, setRating, size, color }: StarProps) => {
   return (
     <div className="flex gap-1">
       {Array.from({ length: 5 }).map((_, index) => (
         <div className="flex cursor-pointer" key={index}>
           <FaStar
-            className={rating > index ? 'text-pink' : 'text-gray_1'}
+            className={rating > index ? (color ? color : 'text-pink') : 'text-gray_1'}
             size={size}
             onClick={() => setRating(index + 1)}
           />
@@ -21,4 +22,5 @@ const Star = ({ rating, setRating, size }: StarProps) => {
     </div>
   );
 };
+
 export default Star;

--- a/src/components/Zip/ZipInfo.tsx
+++ b/src/components/Zip/ZipInfo.tsx
@@ -3,38 +3,44 @@ import { IoIosCall } from 'react-icons/io';
 
 const ZipInfo = () => {
   return (
-    <div className="flex justify-between border-b-[0.5px] border-main_2 pb-[18px] text-[14px]">
-      <div className="flex flex-col">
-        {/* 서점 이름 */}
-        <p className="mb-[2px] text-[15px] font-bold tracking-[-0.56px] text-main_1">진시황 서점</p>
-        {/* 별점 및 종류 */}
-        <div className="flex items-center gap-[6px]">
-          <div className="flex items-center gap-1">
-            <FaStar className="h-[10px] w-[10px] fill-[#0000008A]" />
-            <p className="text-gray_1">4.3</p>
+    <div className="bg-yellow mt-4 flex w-full flex-col items-center gap-4 rounded-[40px] px-7 py-5">
+      {/* 서점 이름 */}
+      <h3 className="text-[15px] font-semibold text-bg">하늘밭봄</h3>
+      {/* 서점 상세 및 좋아요 */}
+      <div className="flex w-full justify-between">
+        <div className="flex flex-col text-[13px] leading-[18px]">
+          {/* 전화번호 */}
+          <div className="flex items-center gap-[2px]">
+            <IoIosCall className="h-[12px] w-[12px] fill-[#0000008A]" />
+            <p className="text-gray_1">02-0000-0000</p>
           </div>
-          <div className="h-[10px] w-[1px] bg-[#D9D9D9]"></div>
-          <p className="text-gray_1">카페가 있는 서점</p>
+          {/* 영업시간 */}
+          <div className="flex items-center gap-[4px]">
+            <FaClock className="h-[10px] w-[10px] fill-[#0000008A]" />
+            <p className="text-gray_1">10:30 ~ 22:00</p>
+          </div>
+          <div className="flex items-center gap-[6px]">
+            <div className="flex items-center gap-1">
+              <FaStar className="h-[10px] w-[10px] fill-[#0000008A]" />
+              <p className="text-gray_1">4.3</p>
+            </div>
+            <div className="h-[10px] w-[1px] bg-[#D9D9D9]"></div>
+            <p className="text-gray_1">인문서적</p>
+          </div>
+          {/* 위치 */}
+          <p className="text-gray_1">인천 연수구 청능대로113번길 37</p>
         </div>
-        {/* 전화번호 */}
-        <div className="flex items-center gap-[2px]">
-          <IoIosCall className="h-[12px] w-[12px] fill-[#0000008A]" />
-          <p className="text-gray_1">02-0000-0000</p>
+        {/* 좋아요 */}
+        <div className="flex flex-col items-center">
+          <div className="flex h-6 w-6 items-center justify-center rounded-full bg-bg">
+            <FaHeart className="h-3 w-3 fill-orange" />
+          </div>
+          <p className="text-[12px] text-gray_1">12</p>
         </div>
-        {/* 영업시간 */}
-        <div className="flex items-center gap-[4px]">
-          <FaClock className="h-[10px] w-[10px] fill-[#0000008A]" />
-          <p className="text-gray_1">10:30 ~ 22:00</p>
-        </div>
-        {/* 위치 */}
-        <p className="text-gray_1">인천 연수구 청능대로113번길 37</p>
       </div>
-      <div className="flex flex-col items-center gap-1">
-        <div className="flex h-5 w-5 items-center justify-center rounded-full border-[0.5px] border-[#BCB3B3]">
-          <FaHeart className="h-3 w-3 fill-red_1" />
-        </div>
-        <p className="text-gray_1">12</p>
-      </div>
+      <p className="text-[13px] leading-4 text-gray_1">
+        다양한 책과 함께 카페, 편안한 독서 공간을 제공하여 독서와 힐링을 동시에 즐길 수 있는 서점
+      </p>
     </div>
   );
 };

--- a/src/components/Zip/ZipReview.tsx
+++ b/src/components/Zip/ZipReview.tsx
@@ -3,36 +3,40 @@ import image from '../../../public/icons/zip/image.png';
 
 const ZipReview = () => {
   return (
-    <div className="flex flex-col gap-[10px] border-b-[0.5px] pb-[19px] pt-[10px] text-base tracking-normal">
+    <div className="flex flex-col gap-[10px] border-b-[0.5px] border-[#D9D9D9] px-2 pb-[19px] pt-[10px] text-base tracking-normal">
       {/* 글씨영역 */}
-      <div className="flex flex-col gap-[3px]">
+      <div className="flex justify-between">
         {/* 이름 날짜 */}
-        <div className="flex items-end gap-[10px] text-[13px]">
-          <p className="text-body3 font-bold text-gray_1">책먹는 여우</p>
-          <p className="text-[13px] font-light text-gray_1">2025.01.31</p>
+        <div className="flex items-end gap-[10px] text-[14px]">
+          <p className="text-body3 font-bold text-white">책먹는 여우</p>
+          <p className="text-[13px] font-light text-gray_1">25.01.31</p>
         </div>
         {/* 별점 */}
         <div className="flex items-center gap-1">
-          <FaStar className="h-[10px] w-[10px] fill-[#0000008A]" />
-          <p className="text-[13px] text-gray_1">4</p>
+          <FaStar className="h-[12px] w-[12px] fill-[#D9D9D9]" />
+          <p className="text-[13px] font-bold text-white">4</p>
         </div>
-        {/* 리뷰 */}
-        <p className="text-[14px] leading-5 tracking-normal text-gray_1">
+      </div>
+      {/* 사진 및 리뷰 */}
+      <div className="flex justify-between gap-4">
+        <img src={image} className="h-[80px] w-[80px] flex-shrink-0" />
+        <p className="text-[13px] leading-5 tracking-normal text-gray_1">
           요즘 자주 찾게 되는 진시황! 몰래 책 먹다가 사장님한테 들켰는데 사장님이 한 번은 봐주신대요... 사장님 진짜
           좋으신 분이세요 ㅠㅠ
         </p>
       </div>
+
       {/* 사진영역 */}
-      <div className="relative">
-        {/* 가로 스크롤 가능한 영역 */}
-        <div className="mx-[-32px] overflow-x-auto px-[32px] scrollbar-hide">
+      {/* <div className="relative"> */}
+      {/* 가로 스크롤 가능한 영역 */}
+      {/* <div className="mx-[-32px] overflow-x-auto px-[32px] scrollbar-hide">
           <div className="flex gap-[10px] after:w-[22px] after:flex-shrink-0 after:content-['']">
             <img src={image} className="h-[80px] w-[80px] flex-shrink-0" />
             <img src={image} className="h-[80px] w-[80px] flex-shrink-0" />
             <img src={image} className="h-[80px] w-[80px] flex-shrink-0" />
           </div>
         </div>
-      </div>
+      </div> */}
     </div>
   );
 };

--- a/src/pages/Booksnap/CreateBooksnapReview1.tsx
+++ b/src/pages/Booksnap/CreateBooksnapReview1.tsx
@@ -55,7 +55,7 @@ const CreateBooksnapReview = () => {
         <div className="my-6">
           {bookInfo.length > 0 ? (
             <div className="flex flex-col gap-6">
-              <FilterBar first="책 제목" second="작가" onChange={handleFilterChange} />
+              <FilterBar first="책 제목" second="작가" onChange={handleFilterChange} color="bg-pink" />
               <div className="grid grid-cols-3 gap-7 overflow-y-auto">
                 {bookInfo.map((book) => (
                   <BookInfo bookInfo={book} key={book.isbn} onClick={() => goToStep2(book)} />

--- a/src/pages/Booksnap/IndiCreateBookReveiw1.tsx
+++ b/src/pages/Booksnap/IndiCreateBookReveiw1.tsx
@@ -56,7 +56,7 @@ const IndiCreateBookReview = () => {
         <div className="my-6">
           {bookInfo.length > 0 ? (
             <div className="flex flex-col gap-6">
-              <FilterBar first="책 제목" second="작가" onChange={handleFilterChange} />
+              <FilterBar first="책 제목" second="작가" onChange={handleFilterChange} color="bg-pink" />
               <div className="grid grid-cols-3 gap-7 overflow-y-auto">
                 {bookInfo.map((book) => (
                   <BookInfo bookInfo={book} key={book.isbn} onClick={() => goToStep2(book)} />

--- a/src/pages/Zip/CreateReview.tsx
+++ b/src/pages/Zip/CreateReview.tsx
@@ -90,7 +90,7 @@ const CreateReview = () => {
         </div>
 
         <div className="w-full">
-          <Button text="리뷰 등록" onClick={handleReviewPost} />
+          <Button text="리뷰 등록" onClick={handleReviewPost} color="green" />
         </div>
       </div>
     </div>

--- a/src/pages/Zip/CreateReview.tsx
+++ b/src/pages/Zip/CreateReview.tsx
@@ -1,19 +1,18 @@
-import Header from '../../components/Common/Header';
-import ZipInfo from '../../components/Zip/ZipInfo';
-import addImage from '../../../public/icons/zip/addImage.png';
 import WritingReview from '../../components/Zip/WritingReview';
 import Button from '../../components/Button/Button';
 import Star from '../../components/Zip/Star';
 import { ChangeEvent, useState } from 'react';
+import { FaAngleLeft } from 'react-icons/fa6';
+import { useNavigate } from 'react-router-dom';
+import AddPhotoAlternateIcon from '@mui/icons-material/AddPhotoAlternate';
 
 const CreateReview = () => {
   const [rating, setRating] = useState(0);
-  const [imageList, setImageList] = useState<File[]>([]); //
-  //  이미지 목록
-  const [previewList, setPreviewList] = useState<string[]>([]); // 미리보기용 URL 저장
+  const [imageList, setImageList] = useState<File[]>([]);
+  const [previewList, setPreviewList] = useState<string[]>([]);
   const [review, setReview] = useState<string>('');
+  const nav = useNavigate();
 
-  // 파일 선택 시 실행될 함수
   const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
     const files = event.target.files;
     if (files) {
@@ -25,53 +24,72 @@ const CreateReview = () => {
     }
   };
 
-  // 리뷰 등록 함수
   const handleReviewPost = () => {
-    // 리뷰 등록 API
     console.log('별점', rating);
     console.log('사진', imageList);
     console.log('리뷰:', review);
   };
 
   return (
-    <div className="flex flex-col text-base tracking-normal">
-      <Header title="리뷰 쓰기" />
-      <div className="flex flex-col px-[32px] pt-[32px]">
-        <div>
-          {/* 서점 정보 */}
-          <ZipInfo />
-        </div>
-        <div className="mt-[18px] flex flex-col gap-[18px]">
-          {/* 별점 */}
-          <Star setRating={setRating} rating={rating} size={18} />
-          {/* 사진 추가 */}
-          <div className="relative flex h-[80px] gap-[14px]">
-            {/* 사진 추가 버튼 */}
-            <label className="flex-shrink-0">
-              <img src={addImage} className="h-[80px] w-[80px] cursor-pointer" />
-              <input type="file" accept="image/*" className="hidden" multiple onChange={handleFileChange} />
-            </label>
-            {/* 가로 스크롤 가능한 영역 (추가된 이미지들만) */}
-            <div className="flex-1 overflow-x-auto whitespace-nowrap scrollbar-hide">
-              <div className="flex gap-[10px]">
-                {previewList.map((src, index) => (
-                  <img
-                    key={index}
-                    src={src}
-                    alt="Preview"
-                    className="h-[80px] w-[80px] rounded-[10px] object-cover"
-                    style={{ minWidth: '80px', minHeight: '80px', maxWidth: '80px', maxHeight: '80px' }}
-                  />
-                ))}
-              </div>
-            </div>
+    <div className="flex w-full flex-col items-center pt-[68px] text-base tracking-normal">
+      {/* 헤더 */}
+      <div className="fixed left-0 right-0 top-0 m-auto w-full max-w-[500px]">
+        <div className="flex items-center bg-bg px-2 py-3">
+          <div className="flex cursor-pointer items-center justify-center p-2.5" onClick={() => nav(-1)}>
+            <FaAngleLeft size={24} className="fill-white" />
           </div>
+          <div className="flex flex-1 items-center justify-center gap-2 text-center text-[20px] font-medium tracking-[-0.8px]">
+            <h3 className="text-orange">리뷰</h3>
+            <h3 className="text-white">작성하기</h3>
+          </div>
+          <div className="w-11" />
+        </div>
+      </div>
+
+      {/* 본문 */}
+      <div className="flex w-full max-w-[500px] flex-col items-center gap-10 px-[32px] pt-[30px]">
+        <p className="border-b-[1px] border-white pb-6 text-body1 font-bold text-green">하늘밭봄</p>
+
+        <div className="mt-[18px] flex w-full flex-col items-center gap-[30px]">
+          {/* 사진 추가 및 미리보기 */}
+          {/* 사진 추가 및 미리보기 */}
+          {previewList.length === 0 ? (
+            // 사진이 하나도 없을 때 → 가운데 정렬
+            <div className="flex justify-center">
+              <label className="border-yellow flex h-[125px] w-[125px] items-center justify-center rounded-[20px] border-[1px]">
+                <AddPhotoAlternateIcon sx={{ fontSize: 25, fill: '#FEF3B1' }} />
+                <input type="file" accept="image/*" className="hidden" multiple onChange={handleFileChange} />
+              </label>
+            </div>
+          ) : (
+            // 사진이 추가되었을 때 → 가로 스크롤 가능한 리스트
+            <div className="flex w-full gap-[10px] overflow-x-auto whitespace-nowrap scrollbar-hide">
+              <label className="border-yellow flex h-[125px] w-[125px] min-w-[125px] shrink-0 items-center justify-center rounded-[20px] border-[1px]">
+                <AddPhotoAlternateIcon sx={{ fontSize: 25, fill: '#FEF3B1' }} />
+                <input type="file" accept="image/*" className="hidden" multiple onChange={handleFileChange} />
+              </label>
+              {previewList.map((src, index) => (
+                <img
+                  key={index}
+                  src={src}
+                  alt={`Preview ${index + 1}`}
+                  className="h-[125px] w-[125px] min-w-[125px] shrink-0 rounded-[20px] object-cover"
+                />
+              ))}
+            </div>
+          )}
+          <p className="mt-[10px] text-[14px] text-white">대표 사진을 등록해주세요.</p>
+
+          {/* 별점 */}
+          <Star setRating={setRating} rating={rating} size={25} color="text-orange" />
+
           {/* 리뷰 작성 */}
-          <div>
+          <div className="w-full">
             <WritingReview onChange={(e) => setReview(e.target.value)} value={review} />
           </div>
         </div>
-        <div className="mt-[5px]">
+
+        <div className="w-full">
           <Button text="리뷰 등록" onClick={handleReviewPost} />
         </div>
       </div>

--- a/src/pages/Zip/ZipDetail.tsx
+++ b/src/pages/Zip/ZipDetail.tsx
@@ -3,6 +3,13 @@ import ZipReview from '../../components/Zip/ZipReview';
 import { useNavigate } from 'react-router-dom';
 import { useBottomSheetStore } from '../../store/bottomSheetStore';
 import ZipInfo from '../../components/Zip/ZipInfo';
+import FilterBar from '../../components/Common/FilterBar';
+import { useState } from 'react';
+import SearchBar from '../../components/Zip/SearchBar';
+import BookInfo from '../../components/Booksnap/BookInfo';
+import { BookDetailInfo } from '../../model/booksnap.model';
+import ReviewAdd from '../../components/Booksnap/ReviewAdd';
+import NoResult from '../../components/Booksnap/NoResult';
 
 interface ZipDetailProps {
   currentState: string;
@@ -11,39 +18,75 @@ interface ZipDetailProps {
 const ZipDetail = ({ currentState }: ZipDetailProps) => {
   const nav = useNavigate();
   const { setBottomSheet } = useBottomSheetStore();
+  const [type, setType] = useState('리뷰');
+  const [searchWord, setSearchWord] = useState('');
+  const [bookInfo, setBookInfo] = useState<BookDetailInfo[]>([]);
 
   const handleWriteReview = () => {
     setBottomSheet(({ currentState }) => <ZipDetail currentState={currentState} />, '서점 상세 정보');
     nav('create-review');
   };
 
+  const handleFilterChange = (selected: string) => {
+    setType(selected);
+    // 리뷰 가져오기
+  };
+
+  const handleSearch = () => {
+    // 보유 서적 받아오기
+  };
+
+  const handleBookInfo = () => {};
+
   return (
-    <div className={`flex w-full flex-col px-[32px] pt-[32px] text-base tracking-normal`}>
+    <div className={`flex w-full flex-col gap-7 px-[27px] pt-[32px] text-base tracking-normal`}>
       {/* 서점 정보 */}
       <ZipInfo />
-      {/* 한줄소개 */}
-      <div className="flex flex-col gap-[10px] border-b-[0.5px] border-gray_1 py-[10px]">
-        <p className="text-[14px] font-medium text-gray_1">한 줄 소개</p>
-        <p className="text-[13px] text-gray_1">
-          다양한 책과 함께 카페, 편안한 독서 공간을 제공하여 독서와 힐링을 동시에 즐길 수 있는 서점
-        </p>
-      </div>
+      {/* 리뷰 및 보유서적 */}
       <div>
-        {/* 리뷰 쓰기 */}
-        <div className="mt-5 flex justify-between text-[13px]">
-          <div className="flex items-center gap-4">
-            <p>• 최신 순</p>
-            <p className="text-gray_1">• 별점 순</p>
+        <FilterBar first="리뷰" second="보유 서적" onChange={handleFilterChange} />
+        {type == '리뷰' ? (
+          <div>
+            <div className="mt-5 flex justify-between text-[13px]">
+              <div className="flex items-center gap-4">
+                <p className="text-orange">• 최신 순</p>
+                <p className="text-white">• 별점 순</p>
+              </div>
+              <ButtonShort type="review" onClick={handleWriteReview} />
+            </div>
+            {/* 리뷰 보여주기 */}
+            <div className="mt-[2px]">
+              <ZipReview />
+              <ZipReview />
+              <ZipReview />
+              <ZipReview />
+            </div>
           </div>
-          <ButtonShort type="review" onClick={handleWriteReview} />
-        </div>
-        {/* 리뷰 보여주기 */}
-        <div className="mt-[2px]">
-          <ZipReview />
-          <ZipReview />
-          <ZipReview />
-          <ZipReview />
-        </div>
+        ) : (
+          <div className="mt-5">
+            <SearchBar
+              searchWord={searchWord}
+              setSearchWord={setSearchWord}
+              onSearch={() => handleSearch()}
+              text="책 제목으로 리뷰를 찾아보세요!"
+            />
+            <div className="my-6">
+              {bookInfo.length > 0 ? (
+                <div className="flex flex-col gap-6">
+                  <FilterBar first="책 제목" second="작가" onChange={handleFilterChange} />
+                  <div className="grid grid-cols-3 gap-7 overflow-y-auto">
+                    {bookInfo.map((book) => (
+                      <BookInfo bookInfo={book} key={book.isbn} onClick={handleBookInfo} />
+                    ))}
+                  </div>
+                </div>
+              ) : (
+                <NoResult text="직접 리뷰를 남겨보세요!" />
+              )}
+            </div>
+          </div>
+        )}
+        {/* 리뷰 쓰기 */}
       </div>
     </div>
   );

--- a/src/pages/Zip/ZipDetail.tsx
+++ b/src/pages/Zip/ZipDetail.tsx
@@ -39,12 +39,12 @@ const ZipDetail = ({ currentState }: ZipDetailProps) => {
   const handleBookInfo = () => {};
 
   return (
-    <div className={`flex w-full flex-col gap-7 px-[27px] pt-[32px] text-base tracking-normal`}>
+    <div className={`flex w-full flex-col gap-7 px-[27px] pt-4 text-base tracking-normal`}>
       {/* 서점 정보 */}
       <ZipInfo />
       {/* 리뷰 및 보유서적 */}
       <div>
-        <FilterBar first="리뷰" second="보유 서적" onChange={handleFilterChange} />
+        <FilterBar first="리뷰" second="보유 서적" onChange={handleFilterChange} color="bg-orange" />
         {type == '리뷰' ? (
           <div>
             <div className="mt-5 flex justify-between text-[13px]">
@@ -81,7 +81,7 @@ const ZipDetail = ({ currentState }: ZipDetailProps) => {
                   </div>
                 </div>
               ) : (
-                <NoResult text="직접 리뷰를 남겨보세요!" />
+                <NoResult text="직접 리뷰를 남겨보세요!" color="yellow" />
               )}
             </div>
           </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -39,6 +39,7 @@ export default {
         blue: '#9DB2CE',
         mint: '#C0E0D8',
         pink: '#F9D6E7',
+        yellow: '#F6ECC9',
       },
       backgroundImage: {
         'key-gradient': 'linear-gradient(180deg, #E1ECF6 0%, #DAE4FD 31%, #DBE5FD 61.5%, #EAF1F8 100%)',


### PR DESCRIPTION
## 🔥 Issues

이슈 연결

## ✅ What to do

- [x] 서점 상세 UI
- [x] 서점 리뷰 UI
- [x] 자잘한 UI들 수정

## 📄 Description
* 서점 상세 UI 바뀐 디자인으로 수정 및 서점이 보유한 책 볼 수 있는 UI 추가
* 서점 리뷰 UI 바뀐 디자인으로 수정

## 🤔 Considerations
### 🛠 FilterBar 디자인 문제 및 해결
* 선택되지 않은 탭에만 border가 있어야했음
* 부모의 `border`를 제거하고, 각 탭에 개별적으로 `border` 추가 후 선택되지 않은 탭에서 가운데 겹치는 border 제거
   - 왼쪽 탭이 선택된 경우, 오른쪽 탭에 `border-l-0` 적용.
   - 오른쪽 탭이 선택된 경우, 왼쪽 탭에 `border-r-0` 적용.
   
### 🛠 사진 추가 라벨 및 미리보기 UI 
- 초기에는 사진 추가 라벨이 화면 좌측 정렬되어 가운데 정렬이 되지 않음
- 사진이 하나라도 추가되면 라벨과 이미지가 수직으로 나열되지 않고 정렬이 어색함
- 사진이 없는 경우: `flex justify-center`로 감싸 가운데 정렬되도록 처리
- 사진이 추가된 경우: 라벨과 이미지들을 동일한 row에 정렬하고 `overflow-x-auto`로 스크롤 가능하게 설정
  - 각 아이템에 `min-w-[125px]`와 `shrink-0`을 부여하여 동일 크기 유지 및 줄어들지 않게 고정

## 🛠️ Improvements to Make

개선할 사항

## 👀 References
<img width="340" alt="image" src="https://github.com/user-attachments/assets/4b511282-be48-4c22-ae7f-6698c2ecf34c" />
<img width="342" alt="image" src="https://github.com/user-attachments/assets/eab2df4d-71f6-4e0b-be0e-9dcc43e05234" />
<img width="343" alt="image" src="https://github.com/user-attachments/assets/92843f11-04d7-4baa-9575-84efc6c5ec36" />
<img width="341" alt="image" src="https://github.com/user-attachments/assets/790b791b-9729-46f8-9ca7-fc4425a498b0" />

