### PR TITLE
[Feat] 서점 보유 도서 API 연동 및 독립 출판물 등록시 이미지 크롭

### DIFF
--- a/src/api/zip.api.ts
+++ b/src/api/zip.api.ts
@@ -50,9 +50,9 @@ export const likeZip = async (bookstoreId: number) => {
 };
 
 // 서점 상세 정보
-export const getZipDetail = async (bookstoreId: number) => {
+export const getZipDetail = async (bookstoreId: number, type: string) => {
   try {
-    const response = await instance.get(`api/bookstores/${bookstoreId}`);
+    const response = await instance.get(`api/bookstores/${bookstoreId}/details?type=${type}`);
     if (response.status == 200) {
       return response.data;
     }

--- a/src/components/Booksnap/BookInfo.tsx
+++ b/src/components/Booksnap/BookInfo.tsx
@@ -14,7 +14,7 @@ const BookInfo = ({ bookInfo, onClick }: BookInfoProps) => {
         className="w-20"
         style={{ boxShadow: '0px 4px 4px 0px rgba(0, 0, 0, 0.25)' }}
       />
-      <div className="flex flex-col gap-[10px]">
+      <div className={`flex flex-col ${bookInfo.publisher ? 'gap-[10px]' : 'gap-[3px]'}`}>
         <p className="text-[15px] font-semibold tracking-[-0.56px] text-white">
           {bookInfo.title.length > 14 ? bookInfo.title.substring(0, 14) + '⋯' : bookInfo.title}
         </p>

--- a/src/components/Zip/NoBookStoreResult.tsx
+++ b/src/components/Zip/NoBookStoreResult.tsx
@@ -10,7 +10,6 @@ interface NoResultProps {
 const NoBookStoreResult = ({ firstText, secondText, type }: NoResultProps) => {
   return (
     <div className="flex w-full flex-col items-center justify-center">
-      <div className="mt-[12px] h-[0.5px] w-full bg-[#979797]"></div>
       {type == 'book' ? <Book className="mb-[5px] mt-[30px]" /> : <Ping className="mb-[5px] mt-[30px]" />}
       <p className="text-[14px] text-[#979797]">{firstText}</p>
       <p className="text-[14px] font-medium leading-7 text-white">{secondText}</p>

--- a/src/model/booksnap.model.ts
+++ b/src/model/booksnap.model.ts
@@ -16,9 +16,9 @@ export interface BookDetailInfo {
   title: string;
   bookImageUrl: string;
   authors: string[];
-  publisher: string | null;
+  publisher?: string | null;
   bookType: 'normal' | 'indep';
-  bookStores: Bookstore[] | null;
+  bookStores?: Bookstore[] | null;
 }
 
 export interface Bookstore {

--- a/src/model/zip.model.ts
+++ b/src/model/zip.model.ts
@@ -41,3 +41,11 @@ export interface postReview {
   rating: number;
   text: string;
 }
+
+// // 보유 도서
+// export interface haveBooks {
+//   authors: string[];
+//   bookId: number;
+//   bookImageUrl: string;
+//   title: string;
+// }

--- a/src/pages/Booksnap/CreateBook.tsx
+++ b/src/pages/Booksnap/CreateBook.tsx
@@ -8,6 +8,7 @@ import Step from '../../components/Booksnap/Step';
 import AddBookstore from '../../components/Booksnap/AddBookstore';
 import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
 import { postIndepBook } from '../../api/booksnap.api';
+import cropImage from '../../utils/cropImage';
 
 export type Option = {
   bookstoreId: number;
@@ -28,7 +29,7 @@ const CreateBook = () => {
 
   const [selectedBookstores, setSelectedBookstores] = useState<readonly Option[]>([]);
 
-  const handleReviewPost = () => {
+  const handleReviewPost = async () => {
     const bookstoreIds = selectedBookstores.map((b) => b.bookstoreId);
 
     const payload = {
@@ -38,7 +39,14 @@ const CreateBook = () => {
       rating: rating,
       reviewText: review,
     };
-    postIndepBook(imageList[0], payload).then(() => {
+
+    let imageToUpload = imageList[0];
+
+    if (imageList[0]) {
+      const url = URL.createObjectURL(imageList[0]);
+      imageToUpload = await cropImage(url, 80, 120); // 자른 File 반환
+    }
+    postIndepBook(imageToUpload, payload).then(() => {
       nav('/booksnap');
     });
   };

--- a/src/pages/Zip/ZipDetail.tsx
+++ b/src/pages/Zip/ZipDetail.tsx
@@ -44,9 +44,7 @@ const ZipDetail = ({ currentState, id }: ZipDetailProps) => {
     setType(selected);
   };
 
-  const handleSearch = () => {
-    // 보유 서적 받아오기
-  };
+  const handleSearch = () => {};
 
   useEffect(() => {
     const detail = type === '리뷰' ? 'reviews' : 'books';
@@ -81,10 +79,13 @@ const ZipDetail = ({ currentState, id }: ZipDetailProps) => {
             </div>
             {/* 리뷰 보여주기 */}
             <div className="mt-[2px]">
-              {reviewList ? (
+              {reviewList.length > 0 ? (
                 reviewList.map((review) => <ZipReview review={review} key={review.createdAt} />)
               ) : (
-                <NoBookStoreResult firstText="아직 등록된 리뷰가 없어요!" type="book" />
+                <>
+                  <div className="mt-[12px] h-[0.5px] w-full bg-[#979797]"></div>
+                  <NoBookStoreResult firstText="아직 등록된 리뷰가 없어요!" type="book" />
+                </>
               )}
             </div>
           </div>
@@ -99,16 +100,13 @@ const ZipDetail = ({ currentState, id }: ZipDetailProps) => {
             <div className="my-6">
               {/* 수정필요 */}
               {bookList.length > 0 ? (
-                <div className="flex flex-col gap-6">
-                  <FilterBar first="책 제목" second="작가" onChange={handleFilterChange} />
-                  <div className="grid grid-cols-3 gap-7 overflow-y-auto">
-                    {bookList.map((book) => (
-                      <BookInfo bookInfo={book} key={book.bookId} onClick={handleBookInfo} />
-                    ))}
-                  </div>
+                <div className="grid grid-cols-3 gap-7 overflow-y-auto">
+                  {bookList.map((book) => (
+                    <BookInfo bookInfo={book} key={book.bookId} onClick={handleBookInfo} />
+                  ))}
                 </div>
               ) : (
-                <NoResult text="검색 결과가 없어요!" />
+                <NoBookStoreResult firstText="아직 보유한 도서에 대한 정보가 없어요!" type="book" />
               )}
             </div>
           </div>

--- a/src/pages/Zip/ZipDetail.tsx
+++ b/src/pages/Zip/ZipDetail.tsx
@@ -10,7 +10,6 @@ import BookInfo from '../../components/Booksnap/BookInfo';
 import { getZipDetail } from '../../api/zip.api';
 import { bookstoreReview, zipPreview } from '../../model/zip.model';
 import NoBookStoreResult from '../../components/Zip/NoBookStoreResult';
-import NoResult from '../../components/Booksnap/NoResult';
 import { BookDetailInfo } from '../../model/booksnap.model';
 
 interface ZipDetailProps {
@@ -26,6 +25,7 @@ const ZipDetail = ({ currentState, id }: ZipDetailProps) => {
   const [bookstoreInfo, setBookstoreInfo] = useState<zipPreview>();
   const [reviewList, setReviewList] = useState<bookstoreReview[]>([]);
   const [bookList, setBookList] = useState<BookDetailInfo[]>([]);
+  const [filteredBookList, setFilteredBookList] = useState<BookDetailInfo[]>([]);
 
   const handleWriteReview = () => {
     // setBottomSheet(({ currentState }) => <ZipDetail currentState={currentState} id={id} />, '서점 상세 정보');
@@ -44,8 +44,6 @@ const ZipDetail = ({ currentState, id }: ZipDetailProps) => {
     setType(selected);
   };
 
-  const handleSearch = () => {};
-
   useEffect(() => {
     const detail = type === '리뷰' ? 'reviews' : 'books';
     getZipDetail(id, detail).then((data) => {
@@ -55,9 +53,21 @@ const ZipDetail = ({ currentState, id }: ZipDetailProps) => {
       }
       if (data.data.bookList) {
         setBookList(data.data.bookList);
+        setFilteredBookList(data.data.bookList);
       }
     });
   }, [type]);
+
+  const handleSearch = () => {
+    if (!searchWord.trim()) {
+      setFilteredBookList(bookList);
+      return;
+    }
+
+    console.log(searchWord);
+    const filtered = bookList.filter((book) => book.title.toLowerCase().includes(searchWord.trim().toLowerCase()));
+    setFilteredBookList(filtered);
+  };
 
   const handleBookInfo = () => {};
 
@@ -99,9 +109,9 @@ const ZipDetail = ({ currentState, id }: ZipDetailProps) => {
             />
             <div className="my-6">
               {/* 수정필요 */}
-              {bookList.length > 0 ? (
+              {filteredBookList.length > 0 ? (
                 <div className="grid grid-cols-3 gap-7 overflow-y-auto">
-                  {bookList.map((book) => (
+                  {filteredBookList.map((book) => (
                     <BookInfo bookInfo={book} key={book.bookId} onClick={handleBookInfo} />
                   ))}
                 </div>

--- a/src/pages/Zip/ZipDetail.tsx
+++ b/src/pages/Zip/ZipDetail.tsx
@@ -11,6 +11,7 @@ import { getZipDetail } from '../../api/zip.api';
 import { bookstoreReview, zipPreview } from '../../model/zip.model';
 import NoBookStoreResult from '../../components/Zip/NoBookStoreResult';
 import NoResult from '../../components/Booksnap/NoResult';
+import { BookDetailInfo } from '../../model/booksnap.model';
 
 interface ZipDetailProps {
   currentState: string;
@@ -24,6 +25,7 @@ const ZipDetail = ({ currentState, id }: ZipDetailProps) => {
   const [searchWord, setSearchWord] = useState('');
   const [bookstoreInfo, setBookstoreInfo] = useState<zipPreview>();
   const [reviewList, setReviewList] = useState<bookstoreReview[]>([]);
+  const [bookList, setBookList] = useState<BookDetailInfo[]>([]);
 
   const handleWriteReview = () => {
     // setBottomSheet(({ currentState }) => <ZipDetail currentState={currentState} id={id} />, '서점 상세 정보');
@@ -31,19 +33,33 @@ const ZipDetail = ({ currentState, id }: ZipDetailProps) => {
   };
 
   useEffect(() => {
-    getZipDetail(id).then((data) => {
+    getZipDetail(id, 'reviews').then((data) => {
       setBookstoreInfo(data.data.bookstoreDetail);
       setReviewList(data.data.reviewList);
     });
   }, []);
 
   const handleFilterChange = (selected: string) => {
+    console.log(selected);
     setType(selected);
   };
 
   const handleSearch = () => {
     // 보유 서적 받아오기
   };
+
+  useEffect(() => {
+    const detail = type === '리뷰' ? 'reviews' : 'books';
+    getZipDetail(id, detail).then((data) => {
+      setBookstoreInfo(data.data.bookstoreDetail);
+      if (data.data.reviewList) {
+        setReviewList(data.data.reviewList);
+      }
+      if (data.data.bookList) {
+        setBookList(data.data.bookList);
+      }
+    });
+  }, [type]);
 
   const handleBookInfo = () => {};
 
@@ -65,8 +81,8 @@ const ZipDetail = ({ currentState, id }: ZipDetailProps) => {
             </div>
             {/* 리뷰 보여주기 */}
             <div className="mt-[2px]">
-              {reviewList.length > 0 ? (
-                reviewList.map((review) => <ZipReview review={review} />)
+              {reviewList ? (
+                reviewList.map((review) => <ZipReview review={review} key={review.createdAt} />)
               ) : (
                 <NoBookStoreResult firstText="아직 등록된 리뷰가 없어요!" type="book" />
               )}
@@ -82,14 +98,14 @@ const ZipDetail = ({ currentState, id }: ZipDetailProps) => {
             />
             <div className="my-6">
               {/* 수정필요 */}
-              {bookstoreInfo ? (
+              {bookList.length > 0 ? (
                 <div className="flex flex-col gap-6">
                   <FilterBar first="책 제목" second="작가" onChange={handleFilterChange} />
-                  {/* <div className="grid grid-cols-3 gap-7 overflow-y-auto">
-                    {bookstoreInfo.map((book) => (
+                  <div className="grid grid-cols-3 gap-7 overflow-y-auto">
+                    {bookList.map((book) => (
                       <BookInfo bookInfo={book} key={book.bookId} onClick={handleBookInfo} />
                     ))}
-                  </div> */}
+                  </div>
                 </div>
               ) : (
                 <NoResult text="검색 결과가 없어요!" />

--- a/src/utils/cropImage.ts
+++ b/src/utils/cropImage.ts
@@ -1,0 +1,55 @@
+const cropImage = (url: string, displayWidth: number, displayHeight: number): Promise<File> => {
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.src = url;
+    img.onload = () => {
+      const canvas = document.createElement('canvas');
+      const ctx = canvas.getContext('2d');
+
+      const scale = 2; // ✅ 2배 해상도
+      canvas.width = displayWidth * scale;
+      canvas.height = displayHeight * scale;
+
+      const aspectRatioImg = img.width / img.height;
+      const aspectRatioCanvas = displayWidth / displayHeight;
+
+      let sx = 0,
+        sy = 0,
+        sWidth = img.width,
+        sHeight = img.height;
+
+      if (aspectRatioImg > aspectRatioCanvas) {
+        sWidth = img.height * aspectRatioCanvas;
+        sx = (img.width - sWidth) / 2;
+      } else {
+        sHeight = img.width / aspectRatioCanvas;
+        sy = (img.height - sHeight) / 2;
+      }
+
+      ctx?.drawImage(
+        img,
+        sx,
+        sy,
+        sWidth,
+        sHeight,
+        0,
+        0,
+        canvas.width,
+        canvas.height, // ✅ 2배 크기로 그리기
+      );
+
+      canvas.toBlob(
+        (blob) => {
+          if (blob) {
+            const file = new File([blob], 'thumbnail.jpg', { type: 'image/jpeg' });
+            resolve(file);
+          }
+        },
+        'image/jpeg',
+        0.95,
+      );
+    };
+  });
+};
+
+export default cropImage;


### PR DESCRIPTION
## 🔥 Issues

이슈 연결

## ✅ What to do

- [x] 서점 보유 도서 API 연동
- [x] 독립 출판물 등록시 이미지 크롭
- [x] 보유 도서 없을 때 UI

## 📄 Description
* 서점 상세에서 보유 도서 API가 추가되어 API 코드를 수정 및 추가
* 독립 출판물 등록 시 사용자가 올리는 파일 크기가 모두 다르기 때문에, 썸네일 이미지와 같게 잘라서 서버로 전송하도록 코드 수정

## 🤔 Considerations
### 🌁 이미지 크롭 문제 해결 과정

- 이미지를 등록할 때 **썸네일처럼 보이는 형태 그대로** 서버에 업로드하고 싶었음
  - 초기에는 CSS로 width, height, object-cover를 줘서 작게 보이게만 했지만  
  → 실제로는 원본 이미지 전체가 업로드되어 용량도 크고, 보이는 것과 달랐음
- 그래서 canvas를 이용한 이미지 자르기 함수 `cropImage`를 따로 구현
  - object-cover처럼 보이도록 이미지 중앙 기준으로 crop해 미리보기와 동일한 비율 유지
- 하지만 crop한 이미지는 화질이 너무 낮고, 흐릿하게 저장됨 (canvas 사이즈가 작아서 실제 픽셀 수가 너무 적었음)
- 화질 개선을 위해 canvas에 2배 해상도(scale = 2)를 적용하여 화질 개선 
  - drawImage 시 object-fit: cover 기준처럼 crop 위치 계산  
  - canvas 결과를 Blob으로 만들고 → File로 변환  
  - JPEG 포맷 + 퀄리티 0.95 설정해 용량은 적당히 유지


## 🛠️ Improvements to Make
* 생각해보니까 비율로 자르는게 나았을 것 같기도 하다.

## 👀 References
<img width="342" alt="image" src="https://github.com/user-attachments/assets/3c8e4e82-a4c5-47c0-9a59-c013404a1ceb" />
