### PR TITLE
[Fix] 바텀시트 스크롤 오류 해결

### DIFF
--- a/src/hooks/useBottomSheet.ts
+++ b/src/hooks/useBottomSheet.ts
@@ -88,21 +88,31 @@ export default function useBottomSheet() {
         return true;
       }
 
-      if (currentStateValue === 'max' && isContentAreaTouched) {
+      if (currentStateValue === 'max') {
+        if (!isContentAreaTouched) {
+          // 콘텐츠 영역 아닌 곳을 터치했을 때는 바텀시트 이동 허용
+          return true;
+        }
+
         const contentElement = content.current!;
-        const scrollableElement = contentElement.querySelector('[data-scrollable]'); // 스크롤 가능한 내부 요소 찾기
+        const scrollableElement = contentElement.querySelector('[data-scrollable]');
 
         if (scrollableElement) {
-          const isAtTop = scrollableElement.scrollTop <= 0; // 내부 요소가 맨 위인지 확인
+          const isAtTop = scrollableElement.scrollTop <= 0;
 
-          // 방향이 down이고 스크롤이 맨 위에 있을 때만 바텀시트 이동 허용
+          // 맨 위 + 아래로 당기는 중일 때만 바텀시트 이동
           if (touchMove.movingDirection === 'down' && isAtTop) {
+            console.log('dd');
             return true;
           }
-          // 다른 경우 내부 스크롤 우선 허용
+
+          // 그 외엔 내부 스크롤 우선
           return false;
         }
+
+        return false; // scrollableElement 못 찾으면 안전하게 false
       }
+
       // 기본적으로 바텀시트 이동 허용
       return true;
     };
@@ -133,11 +143,17 @@ export default function useBottomSheet() {
         touchMove.movingDirection = 'up';
       }
 
+      console.log(touchMove.movingDirection);
+
       const canMoveBottomSheet = canUserMoveBottomSheet();
 
+      const isNotMaxState = currentStateRef.current !== 'max';
+
+      const isPullingDownInMax = currentStateRef.current === 'max' && touchMove.movingDirection === 'down';
+
       // 바텀시트 이동 가능 여부 확인
-      if (canMoveBottomSheet) {
-        e.preventDefault(); // 바텀시트 이동을 위해 기본 동작 차단
+      if (canMoveBottomSheet && (isNotMaxState || isPullingDownInMax)) {
+        e.preventDefault();
 
         const touchOffset = currentTouch.clientY - touchStart.touchY;
         let nextSheetY = touchStart.sheetY + touchOffset;
@@ -153,7 +169,6 @@ export default function useBottomSheet() {
         requestAnimationFrame(() => {
           const scrollableElement = content.current?.querySelector('[data-scrollable]');
           if (scrollableElement instanceof HTMLElement) {
-            console.log('잘됨');
             scrollableElement.style.overflowY = 'auto';
           }
         });

--- a/src/hooks/useBottomSheet.ts
+++ b/src/hooks/useBottomSheet.ts
@@ -81,8 +81,6 @@ export default function useBottomSheet() {
       const { touchMove, isContentAreaTouched } = metrics.current;
       const currentStateValue = currentStateRef.current;
 
-      // console.log(currentStateValue);
-
       // 상태가 mid인 경우 바텀시트는 무조건 이동
       if (currentStateValue === 'mid') {
         return true;
@@ -102,7 +100,6 @@ export default function useBottomSheet() {
 
           // 맨 위 + 아래로 당기는 중일 때만 바텀시트 이동
           if (touchMove.movingDirection === 'down' && isAtTop) {
-            console.log('dd');
             return true;
           }
 
@@ -143,8 +140,6 @@ export default function useBottomSheet() {
         touchMove.movingDirection = 'up';
       }
 
-      console.log(touchMove.movingDirection);
-
       const canMoveBottomSheet = canUserMoveBottomSheet();
 
       const isNotMaxState = currentStateRef.current !== 'max';
@@ -184,7 +179,6 @@ export default function useBottomSheet() {
 
       if (!canMoveBottomSheet) {
         // 내부 스크롤이 필요한 경우, 바텀시트 동작을 막음
-        console.log('내부 스크롤 중 - 바텀시트 동작 차단');
         return;
       }
 
@@ -200,18 +194,15 @@ export default function useBottomSheet() {
             sheet.current!.style.setProperty('transform', `translateY(${MID_Y - MAX_Y}px)`); // 최대 -> 중간
             setCurrentState('mid');
             setCurrentHeight(BOTTOM_SHEET_HEIGHT_MID);
-            console.log('최대, 중간', BOTTOM_SHEET_HEIGHT_MID, 'state', currentState);
           } else if (isMovingUp) {
             sheet.current!.style.setProperty('transform', `translateY(${MIN_Y - MAX_Y}px)`); // 중간 -> 최대
             setCurrentHeight(BOTTOM_SHEET_HEIGHT_MAX);
             setCurrentState('max');
-            console.log(currentHeight);
           }
         } else if (currentSheetY <= MAX_Y && currentSheetY > MID_Y) {
           if (isMovingDown) {
             sheet.current!.style.setProperty('transform', `translateY(64px)`); // 중간 -> 최소
             setCurrentState('close');
-            console.log('close');
             closeBottomSheet();
           } else if (isMovingUp) {
             sheet.current!.style.setProperty('transform', `translateY(${MID_Y - MAX_Y}px)`); // 최소 -> 중간

--- a/src/pages/Zip/SearchZip.tsx
+++ b/src/pages/Zip/SearchZip.tsx
@@ -26,10 +26,13 @@ export default function SearchZip({ searchResults, currentState }: SearchZipProp
   };
 
   return (
-    <div className={`flex w-full flex-col px-[24px] ${currentState == 'max' ? 'pt-[10px]' : 'pt-[28px]'}`}>
+    <div
+      data-scrollable
+      className={`flex h-full w-full flex-col overflow-y-auto px-[24px] ${currentState == 'max' ? 'pt-[10px]' : 'pt-[28px]'}`}
+    >
       {/* 필터 */}
       <div
-        className="ml-[12px] flex h-[26px] w-[80px] items-center gap-1 rounded-[50px] bg-orange pl-[17px]"
+        className="ml-[12px] flex min-h-[26px] w-[80px] items-center gap-1 rounded-[50px] bg-orange pl-[17px]"
         onClick={() => setIsOpen(!isOpen)}
       >
         <p className="text-[12px]">{FILTER_OPTIONS.find((option) => option.key === currentFilter)?.label}</p>

--- a/src/pages/Zip/ZipDetail.tsx
+++ b/src/pages/Zip/ZipDetail.tsx
@@ -72,7 +72,7 @@ const ZipDetail = ({ currentState, id }: ZipDetailProps) => {
   const handleBookInfo = () => {};
 
   return (
-    <div className={`flex w-full flex-col gap-7 px-[27px] pt-4 text-base tracking-normal`}>
+    <div className={`flex w-full flex-col gap-7 px-[27px] pb-10 pt-4 text-base tracking-normal`}>
       {/* 서점 정보 */}
       {bookstoreInfo && <ZipInfo bookstoreInfo={bookstoreInfo} />}
       {/* 리뷰 및 보유서적 */}


### PR DESCRIPTION
## 🔥 Issues

이슈 연결

## ✅ What to do

- [x] 바텀시트 모바일 스크롤 오류 수정

## 📄 Description
* 바텀시트가 pc에선 스크롤이 되는데, 모바일에선 안됐던 문제를 수정했다.

## 🤔 Considerations
### 🔍 내부 스크롤 영역 인식 오류 해결 (`view()` → 내부 콘텐츠에 `data-scrollable`)
- `data-scrollable`을 `view()` 최상단 요소에 적용해 실제 스크롤되는 콘텐츠를 인식하지 못함
- 스크롤 가능한 내부 콘텐츠에 `data-scrollable`, `overflow-y-auto`, `h-full` 등을 적용해 바텀시트 훅이 스크롤 위치를 정확히 인식하도록 수정


-> 그런데... 이걸 고쳐도 `max` 상태에서 바텀시트 이동이 안됨

### 🧠 `max` 상태에서 바텀시트 이동이 안 됐던 문제 해결
- 원래 조건이 `if (currentStateValue === 'max' && isContentAreaTouched)`였기 때문에  
  → 콘텐츠 영역을 터치하지 않으면 **안쪽 로직이 실행되지 않음**  
  → 바텀시트가 아예 안 내려감

- `if (currentStateValue === 'max') { if (!isContentAreaTouched) { ... } }`로 수정  
  → 먼저 `max` 상태인지 확인한 뒤  
  → 콘텐츠 영역이 **아닌 곳이면 바로 바텀시트 이동 허용**  
  → 콘텐츠 영역이면 별도로 추가 조건 검사

- 조건 분기 방식을 바꾼 것만으로 **정상적으로 스크롤/바텀시트 이동이 분리되어 동작하게 됨**

-> 그런데 바텀시트가 내부 스크롤 중에도 같이 내려감... 올릴 때는 괜찮았는데 내리는 동작하면 같이 내려감


### ⬇️ 바텀시트가 내부 스크롤 중에도 같이 내려가는 문제 해결
- 내부 콘텐츠에 `overflow-y-auto`, `h-full`이 없어 `scrollTop === 0`으로 항상 인식되어 바텀시트가 내려가는 문제가 발생
- 이를 막기 위해 스크롤 가능한 상태인지(`scrollHeight > clientHeight`)를 함께 체크하는 로직으로 개선
- 동시에, 바텀시트가 `max` 상태일 때는 아예 내려가지 않도록 하려고 `isNotMaxState` 조건을 추가했음

-> 이제는 'max' 상태에서 안내려가는 새로운 문제 발생...

### ❌ 바텀시트가 `max` 상태에서 내려가지 않는 문제 해결
- 위 문제를 막기 위해 추가한 `isNotMaxState` 조건으로 인해, `max` 상태에서 아래로 당겨도 바텀시트가 전혀 내려가지 않음
- 이를 해결하기 위해 `max` 상태이면서 아래로 당기는 중일 경우 바텀시트가 내려갈 수 있도록 예외 조건을 확장


## 🛠️ Improvements to Make

개선할 사항

## 👀 References

스크린샷 또는 참고사항
