### PR TITLE
[Fix] 바텀시트 스크롤 오류 수정 및 현위치 오류 해결

### DIFF
--- a/src/constants/BottomSheetOption.ts
+++ b/src/constants/BottomSheetOption.ts
@@ -1,5 +1,5 @@
 export const MIN_Y = 0; // 바텀 시트가 최대로 올라 갔을 때의 Y좌표 값
 export const MAX_Y = window.innerHeight - 160; // 바텀 시트가 최대로 내려갔을 때의 Y좌표 값
-export const MID_Y = 380; // 바텀 시트 중간 값
+export const MID_Y = 340; // 바텀 시트 중간 값
 export const BOTTOM_SHEET_HEIGHT_MAX = window.innerHeight - 65; // 바텀시트 높이
 export const BOTTOM_SHEET_HEIGHT_MID = window.innerHeight - MID_Y; // 바텀시트 높이

--- a/src/pages/Zip/SearchZip.tsx
+++ b/src/pages/Zip/SearchZip.tsx
@@ -1,7 +1,6 @@
 import { IoIosArrowDown } from 'react-icons/io';
 import ZipPreview from '../../components/Zip/ZipPreview';
 import { useState } from 'react';
-import Ping from '../../../public/icons/zip/ping.svg?react';
 import { getZipPreview } from '../../model/zip.model';
 import NoBookStoreResult from '../../components/Zip/NoBookStoreResult';
 
@@ -26,10 +25,7 @@ export default function SearchZip({ searchResults, currentState }: SearchZipProp
   };
 
   return (
-    <div
-      data-scrollable
-      className={`flex h-full w-full flex-col overflow-y-auto px-[24px] ${currentState == 'max' ? 'pt-[10px]' : 'pt-[28px]'}`}
-    >
+    <div className={`flex w-full flex-col px-[24px] ${currentState === 'max' ? 'pt-[10px]' : 'pt-[28px]'}`}>
       {/* 필터 */}
       <div
         className="ml-[12px] flex min-h-[26px] w-[80px] items-center gap-1 rounded-[50px] bg-orange pl-[17px]"
@@ -38,8 +34,9 @@ export default function SearchZip({ searchResults, currentState }: SearchZipProp
         <p className="text-[12px]">{FILTER_OPTIONS.find((option) => option.key === currentFilter)?.label}</p>
         <IoIosArrowDown className="h-3 w-3" />
       </div>
+
       {isOpen && (
-        <div className="absolute left-11 mt-[33px] w-[80px] rounded-[10px] border border-orange bg-[#FFDDD2]">
+        <div className="absolute left-11 z-10 mt-[33px] w-[80px] rounded-[10px] border border-orange bg-[#FFDDD2]">
           {FILTER_OPTIONS.map((option, index) => (
             <div
               key={option.key}
@@ -56,9 +53,13 @@ export default function SearchZip({ searchResults, currentState }: SearchZipProp
 
       {/* 검색결과 */}
       {searchResults.length === 0 ? (
-        <NoBookStoreResult firstText="검색된 서점이 없어요!" secondText="독립 서점 제보하러 가기 &gt;" />
+        <NoBookStoreResult firstText="검색된 서점이 없어요!" secondText="독립 서점 제보하러 가기 >" />
       ) : (
-        searchResults.map((zip, index) => <ZipPreview key={index} index={index} bookstore={zip} />)
+        <div className="mt-4 flex flex-col">
+          {searchResults.map((zip, index) => (
+            <ZipPreview key={index} index={index} bookstore={zip} />
+          ))}
+        </div>
       )}
     </div>
   );

--- a/src/pages/Zip/Zip.tsx
+++ b/src/pages/Zip/Zip.tsx
@@ -12,6 +12,7 @@ import { getZipPreview } from '../../model/zip.model';
 import HomeHeader from '../../components/Header/HomeHeader';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import toast, { Toaster } from 'react-hot-toast';
+import { useGeoLocation } from '../../hooks/useGeolocation';
 import useBottomSheet from '../../hooks/useBottomSheet';
 
 export const BOOKSTORE_OPTIONS = [
@@ -22,7 +23,7 @@ export const BOOKSTORE_OPTIONS = [
 
 const Zip = () => {
   const [isLiked, setIsLiked] = useState<boolean>(false);
-  const [location, setLocation] = useState<ILocation>(defaultLocation);
+  const { location, error } = useGeoLocation();
   const [searchResults, setSearchResults] = useState<getZipPreview[]>([]);
   const { setBottomSheet, closeBottomSheet, isOpen, resultCount } = useBottomSheetStore();
   const [prevView, setPrevView] = useState(() => useBottomSheetStore.getState().prevView || null);


### PR DESCRIPTION
## 🔥 Issues

이슈 연결

## ✅ What to do

- [x] 바텀시트 스크롤 오류 수정
- [x] 현위치 오류 해결

## 📄 Description
* 바텀시트 중간 상태 높이 수정
* 바텀시트 스크롤 오류 수정: 컴포넌트 전체가 아닌 영역이 늘어나도록 수정
* 현위치가 계속 기본 값으로 받아져오는 문제 해결

## 🤔 Considerations
### 📍 현위치가 계속 기본값으로 나오는 문제 해결 (`useGeoLocation` 적용)
- 기존에는 위치 상태를 `useState(defaultLocation)`으로만 설정하고 있어, `navigator.geolocation` 결과를 반영하지 못함
- `useGeoLocation()` 커스텀 훅을 도입하여 `getCurrentPosition()` 호출 → 위치 상태를 외부에서 주입받도록 개선
- HTTPS 환경 및 사용자 위치 권한 여부에 따라 실패 시에도 fallback으로 `defaultLocation` 유지

### ⬇️ 바텀시트 검색 결과가 모바일에서 스크롤 되지 않던 문제 해결
- `SearchZip` 컴포넌트에 직접 `overflow-y-auto`, `data-scrollable`, `h-full` 등을 설정한 상태였으나 실제 기기에서는 바텀시트 훅과의 충돌로 스크롤이 잘 되지 않음
- 기존 구조를 `ZipDetail`처럼 콘텐츠 길이에 따라 바텀시트가 자연스럽게 늘어나도록 단순화
- 동시에 내부 콘텐츠가 너무 길어질 경우를 대비해, `scrollTop` 감지를 위한 명확한 구조 유지

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

스크린샷 또는 참고사항
