### PR TITLE
[Fix] 독립 출판물 등록 시 서점아이디 오류 해결

### DIFF
--- a/src/components/Modal/SearchBookstoreModal.tsx
+++ b/src/components/Modal/SearchBookstoreModal.tsx
@@ -20,9 +20,10 @@ const SearchBookstoreModal = ({ setModalOpen, selected, setSelected }: ModalProp
     debounce((inputValue: string) => {
       searchBookstore(inputValue).then((data) => {
         const mappedOptions: Option[] = data.data.map((item: any) => ({
-          ...item,
           label: item.bookStoreName,
           value: String(item.bookStoreId),
+          bookStoreName: item.bookStoreName,
+          bookstoreId: item.bookStoreId,
         }));
         setBookstoreOptions(mappedOptions);
       });


### PR DESCRIPTION
## 🔥 Issues

이슈 연결

## ✅ What to do

- [x] 독립 출판물 등록 시 서점아이디 오류 해결

## 📄 Description
* 독립 출판물 등록 시 서점아이디 오류 해결

## 🤔 Considerations
### 🔄 검색된 서점 데이터에서 ID 관련 오류 수정

- 초기 `useEffect`로 불러온 서점 데이터는 `bookstoreId`, `bookStoreName` 등의 명확한 키가 있었음
- 하지만 검색 결과로 들어온 데이터는 스프레드 연산자(`...item`)만 적용되어,  
  특정 필드명을 명시하지 않으면 `bookstoreId`가 undefined가 되어 오류 발생
- `map()` 시에 필요한 필드를 명확히 설정해 문제 해결

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

스크린샷 또는 참고사항
