### PR TITLE
[Fix] 외부 검색 진입 시 Location undefined로 나는 오류 해결

### DIFF
--- a/src/pages/Zip/Zip.tsx
+++ b/src/pages/Zip/Zip.tsx
@@ -58,11 +58,11 @@ const Zip = () => {
   }, [isLiked, prevView]);
 
   useEffect(() => {
-    if (searchWordFromQuery) {
+    if (searchWordFromQuery && location) {
       setSearchWord(searchWordFromQuery);
       handleSearch(searchWordFromQuery);
     }
-  }, [searchParams.toString()]);
+  }, [searchParams.toString(), location]);
 
   // 좋아요 처리
   const handleHeart = () => {


### PR DESCRIPTION
## 🔥 Issues

이슈 연결

## ✅ What to do

- [x] 외부 검색 진입 시 Location undefined로 나는 오류 해결

## 📄 Description
* Zip 외부 페이지에서 서점 검색 시 Location undefined로 검색이 실패하는 문제 해결

## 🤔 Considerations
### 🐞외부 검색 진입 시 Location undefined로 나는 오류
- `Zip` 내부에서 직접 검색 시에는 정상 동작하지만,  외부에서 URL로 검색어 param(`?search=...`)을 포함해 접근할 경우 검색 실패
- 컴포넌트가 마운트되자마자 `useEffect`에서 `handleSearch()`가 실행되었는데, 그 시점에는 아직 `useGeoLocation()`의 `location`이 초기화되지 않음
  - `location`이 `undefined` 상태에서 검색 API 호출이 이뤄져 `TypeError` 발생
- `useEffect`의 의존성 배열에 `location`을 추가하여, `location`이 초기화된 이후에만 `handleSearch()`가 실행되도록 조정
  - 조건문에서 `location` 존재 여부까지 체크하여 안전하게 검색 수행

## 🛠️ Improvements to Make

개선할 사항

## 👀 References

스크린샷 또는 참고사항
