### PR TITLE
[Feat] bookie 대화 히스토리 불러오기

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import './App.css';
 import { RouterProvider } from 'react-router-dom';
 import { router } from './routes/router';
 import { useEffect } from 'react';
+import { Toaster } from 'react-hot-toast';
 
 function App() {
   useEffect(() => {
@@ -19,6 +20,7 @@ function App() {
   return (
     <>
       <RouterProvider router={router} />
+      <Toaster />
     </>
   );
 }

--- a/src/api/bookie.api.ts
+++ b/src/api/bookie.api.ts
@@ -16,3 +16,17 @@ export const sendMessageToChatAPI = async (message: string) => {
     throw error;
   }
 };
+
+// 이전 히스토리 가져오기
+export const getHistory = async () => {
+  try {
+    const response = await instance.get('/bookie/history');
+
+    if (response.status === 200) {
+      return response.data;
+    }
+  } catch (error) {
+    console.log(error);
+    throw error;
+  }
+};

--- a/src/api/booksnap.api.ts
+++ b/src/api/booksnap.api.ts
@@ -89,9 +89,9 @@ export const deleteLike = async (bookReviewId: number) => {
 };
 
 // 책 담기
-export const pickBook = async (isbn: string) => {
+export const pickBook = async (bookId: string) => {
   try {
-    const response = await instance.post(`api/pick-book`, { isbn: isbn });
+    const response = await instance.post(`api/pick-book`, { bookId: bookId });
     if (response.status == 201) {
       return { success: true, message: '책이 정상적으로 담겼습니다!' };
     }

--- a/src/components/Common/MenuBar.tsx
+++ b/src/components/Common/MenuBar.tsx
@@ -6,6 +6,7 @@ import SearchIcon from '@mui/icons-material/Search';
 import SmartToyIcon from '@mui/icons-material/SmartToy';
 import RateReviewIcon from '@mui/icons-material/RateReview';
 import Person2Icon from '@mui/icons-material/Person2';
+import toast from 'react-hot-toast';
 
 const MenuBar = () => {
   const nav = useNavigate();
@@ -62,6 +63,14 @@ const MenuBar = () => {
             key={menuItem.name}
             className={`flex cursor-pointer flex-col items-center px-2 ${currentMenu === menuItem.name ? 'pb-[0px] pt-[6px]' : 'py-[6px]'}`}
             onClick={() => {
+              const isAuthenticated = !!localStorage.getItem('accessToken');
+
+              const protectedMenus = ['bookie'];
+
+              if (protectedMenus.includes(menuItem.name) && !isAuthenticated) {
+                toast.error('로그인이 필요한 서비스입니다!');
+                return;
+              }
               nav(menuItem.name);
             }}
           >

--- a/src/pages/Bookie.tsx
+++ b/src/pages/Bookie.tsx
@@ -5,7 +5,7 @@ import Input from '../components/Bookie/Input';
 import { FaRegArrowAltCircleUp } from 'react-icons/fa';
 import { IoCloseOutline } from 'react-icons/io5';
 import { useNavigate } from 'react-router-dom';
-import { sendMessageToChatAPI } from '../api/bookie.api';
+import { getHistory, sendMessageToChatAPI } from '../api/bookie.api';
 import { MdBookmarkAdd } from 'react-icons/md';
 import toast from 'react-hot-toast';
 import { pickBook } from '../api/booksnap.api';
@@ -43,6 +43,12 @@ const Bookie = () => {
       endOfMessages.current.scrollIntoView({ behavior: 'smooth' });
     }
   }, [systemRes]);
+
+  useEffect(() => {
+    getHistory().then((data) => {
+      setSystemRes(data.chat);
+    });
+  }, []);
 
   // 메세지 보내기
   const sendMessage = async () => {


### PR DESCRIPTION
## 🔥 Issue
 #32


## ✅ 작업 내용 (What to do)

- [x] Bookie 대화 히스토리 불러오기
- [x] 로그인하지 않은 사용자의 Bookie 접근 차단
- [x] 책담기 API 요청 바디 필드명 변경 (`bookId` → `id`)


## 📄 변경 사항 설명 (Description)

- 백엔드 API 요청 명세 변경에 따라 `bookId` → `id`로 필드명을 수정
- 로그인하지 않은 사용자가 Bookie 메뉴를 누르면, 이동 없이 토스트 메시지만 뜨도록 처리
- Bookie 대화 히스토리는 사용자 ID 기반으로 불러오도록 구현


## 🤔 고민한 점 (Considerations)

- **ProtectedRoute로 막을지**, **MenuBar에서 클릭 자체를 차단할지** 고민했다.
  - “로그인이 안 되어 있을 경우 클릭해도 **화면 전환 없이** 토스트만 띄워야 한다”는 UX 요구에 따라 **MenuBar에서 제어**하는 방식으로 결정했다.


## 🛠️ 추후 개선 사항 (Improvements)

- 인증이 필요한 페이지는 MenuBar뿐 아니라 라우팅 자체도 차단할 수 있도록  
  **ProtectedRoute 방식으로 전환하는 구조 개선 고려**


## 👀 참고 사항 (References)


