### PR TITLE
[Feat] 북스냅 책 검색 및 사소한 오류들 해결

### DIFF
--- a/src/api/booksnap.api.ts
+++ b/src/api/booksnap.api.ts
@@ -142,3 +142,15 @@ export const postSearchHistory = async (searchType: string, searchWord: string) 
     console.log(err);
   }
 };
+
+// 최근 검색어 불러오기
+export const getRecentSearch = async (searchtype: string, page: number, size: number) => {
+  try {
+    const response = await instance.get(`/api/search-history?searchtype=${searchtype}&page=${page}&size=${size}`);
+    if (response.status === 200) {
+      return response.data;
+    }
+  } catch (err) {
+    console.log(err);
+  }
+};

--- a/src/api/booksnap.api.ts
+++ b/src/api/booksnap.api.ts
@@ -127,3 +127,18 @@ export const searchReview = async (bookName: string) => {
     console.log(err);
   }
 };
+
+// 책 검색 기록 저장
+export const postSearchHistory = async (searchType: string, searchWord: string) => {
+  try {
+    const response = await instance.post(`/api/search-history`, {
+      searchType: searchType,
+      searchWord: searchWord,
+    });
+    if (response.status === 200) {
+      return response.data;
+    }
+  } catch (err) {
+    console.log(err);
+  }
+};

--- a/src/api/booksnap.api.ts
+++ b/src/api/booksnap.api.ts
@@ -115,3 +115,15 @@ export const searchBookstore = async (query: string | null) => {
     console.log(error);
   }
 };
+
+// 책 리뷰검색하기
+export const searchReview = async (bookName: string) => {
+  try {
+    const response = await instance.get(`/api/search?bookName=${bookName}`);
+    if (response.status === 200) {
+      return response.data;
+    }
+  } catch (err) {
+    console.log(err);
+  }
+};

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -24,10 +24,11 @@ instance.interceptors.request.use(
 // 응답 인터셉터
 instance.interceptors.response.use(
   (response) => {
-    const { accessToken, refreshToken } = response.data.data || {};
+    const { accessToken, refreshToken, nickname } = response.data.data || {};
     if (accessToken && refreshToken) {
       localStorage.setItem('accessToken', accessToken);
       localStorage.setItem('refreshToken', refreshToken);
+      localStorage.setItem('nickname', nickname);
     }
     return response;
   },
@@ -57,6 +58,7 @@ instance.interceptors.response.use(
         console.log('Token 갱신 실패:', refreshErr);
         localStorage.removeItem('accessToken');
         localStorage.removeItem('refreshToken');
+        localStorage.removeItem('nickname');
         window.location.href = '/login';
         return Promise.reject(refreshErr);
       }

--- a/src/api/zip.api.ts
+++ b/src/api/zip.api.ts
@@ -52,7 +52,7 @@ export const likeZip = async (bookstoreId: number) => {
 // 서점 상세 정보
 export const getZipDetail = async (bookstoreId: number, type: string, sortFiled: string) => {
   try {
-    const response = await instance.get(`api/bookstores/${bookstoreId}/details?type=${type}&sortFiled?=${sortFiled}`);
+    const response = await instance.get(`api/bookstores/${bookstoreId}/details?type=${type}&sortField=${sortFiled}`);
     if (response.status == 200) {
       return response.data;
     }

--- a/src/components/Header/BookSearchHeader.tsx
+++ b/src/components/Header/BookSearchHeader.tsx
@@ -3,6 +3,7 @@ import Arrow from '../../../public/icons/menu-bar/ArrowLeft.svg?react';
 
 import { useNavigate } from 'react-router-dom';
 import SearchBar from '../Zip/SearchBar';
+import { postSearchHistory } from '../../api/booksnap.api';
 
 const BookSearchHeader = () => {
   const [searchWord, setSearchWord] = useState('');
@@ -10,6 +11,7 @@ const BookSearchHeader = () => {
 
   const handleSearch = () => {
     nav(`/booksnap?query=${searchWord}`);
+    postSearchHistory('booktitle', searchWord);
   };
 
   return (

--- a/src/components/Header/BookSearchHeader.tsx
+++ b/src/components/Header/BookSearchHeader.tsx
@@ -8,7 +8,9 @@ const BookSearchHeader = () => {
   const [searchWord, setSearchWord] = useState('');
   const nav = useNavigate();
 
-  const handleSearch = () => {};
+  const handleSearch = () => {
+    nav(`/booksnap?query=${searchWord}`);
+  };
 
   return (
     <div className="fixed left-0 right-0 top-0 z-20 m-auto flex max-w-[500px] items-center gap-[15px] border-b-[1px] border-[#544F4F] bg-bg px-[20px] py-[10px]">

--- a/src/components/ScrollContext.tsx
+++ b/src/components/ScrollContext.tsx
@@ -1,0 +1,11 @@
+import { createContext, useContext, useRef } from 'react';
+
+export const ScrollContext = createContext<React.RefObject<HTMLDivElement> | null>(null);
+
+export const useScrollRef = () => {
+  const context = useContext(ScrollContext);
+  if (!context) {
+    throw new Error('useScrollRef must be used within a ScrollProvider');
+  }
+  return context;
+};

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1,9 +1,10 @@
 import { Outlet } from 'react-router-dom';
 import MenuBar from './Common/MenuBar';
 import { useEffect, useRef, useState } from 'react';
+import { ScrollContext } from './scrollContext';
 
 const Layout = () => {
-  const headerHeight = useRef<HTMLDivElement>(null);
+  const mainRef = useRef<HTMLDivElement>(null);
   const menuBarHeight = useRef<HTMLDivElement>(null);
   const [heights, setHeights] = useState(0);
 
@@ -24,21 +25,23 @@ const Layout = () => {
   }, []);
 
   return (
-    <div className="relative flex flex-col">
-      <main
-        className="overflow-auto scrollbar-none"
-        style={{
-          // marginTop: `${heights.header}px`,
-          marginBottom: `${heights}px`,
-          height: `calc(100dvh - ${heights}px)`,
-        }}
-      >
-        <Outlet />
-      </main>
-      <footer className="fixed bottom-0 z-30 w-full max-w-[500px]" ref={menuBarHeight}>
-        <MenuBar />
-      </footer>
-    </div>
+    <ScrollContext.Provider value={mainRef}>
+      <div className="relative flex flex-col">
+        <main
+          className="overflow-y-auto scrollbar-none"
+          ref={mainRef}
+          style={{
+            marginBottom: `${heights}px`,
+            height: `calc(100dvh - ${heights}px)`,
+          }}
+        >
+          <Outlet />
+        </main>
+        <footer className="fixed bottom-0 z-30 w-full max-w-[500px]" ref={menuBarHeight}>
+          <MenuBar />
+        </footer>
+      </div>
+    </ScrollContext.Provider>
   );
 };
 

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1,7 +1,7 @@
 import { Outlet } from 'react-router-dom';
 import MenuBar from './Common/MenuBar';
 import { useEffect, useRef, useState } from 'react';
-import { ScrollContext } from './scrollContext';
+import { ScrollContext } from './ScrollContext';
 
 const Layout = () => {
   const mainRef = useRef<HTMLDivElement>(null);

--- a/src/pages/Bookie.tsx
+++ b/src/pages/Bookie.tsx
@@ -30,7 +30,7 @@ const Bookie = () => {
   const [isComposing, setIsComposing] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [loadingMessage, setLoadingMessage] = useState<string>('');
-  const userName = '이구역독서짱';
+  const userName = localStorage.getItem('nickname');
   const [systemRes, setSystemRes] = useState<MessageType[]>([
     {
       text: `안녕하세요! ${userName}님이 좋아하실만한책을 추천해드리는 Bookie입니다! 더 많은 정보를 알려주시면, 책을 찾아드릴게요.`,

--- a/src/pages/Booksnap/BookSearch.tsx
+++ b/src/pages/Booksnap/BookSearch.tsx
@@ -1,23 +1,16 @@
 import RecentSearch from '../../components/Booksnap/RecentSearch';
 import Tag from '../../components/Common/Tag';
-import SearchBar from '../../components/Zip/SearchBar';
-import { useState } from 'react';
-import Arrow from '../../../public/icons/menu-bar/ArrowLeft.svg?react';
-import { useNavigate } from 'react-router-dom';
-import Header from '../../components/Common/Header';
 import BookSearchHeader from '../../components/Header/BookSearchHeader';
 
 const BookSearch = () => {
-  const nav = useNavigate();
-
   const bookname = ['구원의 날', '지구에서 한아뿐', '사이키쿠스오'];
   const recent = ['하이큐 10권', '우리가 빛의 속도로 갈 수 없다면', '천 개의 파랑'];
 
   return (
-    <div className="bg-bg flex h-full flex-col">
+    <div className="flex h-full flex-col bg-bg">
       {/* 헤더 */}
       <BookSearchHeader />
-      <div className="bg-bg mt-[53px] flex flex-col gap-[15px] px-[15px] py-[10px]">
+      <div className="mt-[53px] flex flex-col gap-[15px] bg-bg px-[15px] py-[10px]">
         {/* 인기 검색어 */}
         <div className="flex w-full flex-col gap-[10px] border-b-[1px] border-[#A09F9F] p-[10px] text-body3 font-bold text-white">
           <p>zipzip이들이 많이 찾아본 리뷰</p>

--- a/src/pages/Booksnap/BookSearch.tsx
+++ b/src/pages/Booksnap/BookSearch.tsx
@@ -1,10 +1,23 @@
+import { useEffect, useState } from 'react';
+import { getRecentSearch } from '../../api/booksnap.api';
 import RecentSearch from '../../components/Booksnap/RecentSearch';
 import Tag from '../../components/Common/Tag';
 import BookSearchHeader from '../../components/Header/BookSearchHeader';
 
+interface RecentType {
+  id: number;
+  searchWord: string;
+}
+
 const BookSearch = () => {
   const bookname = ['구원의 날', '지구에서 한아뿐', '사이키쿠스오'];
-  const recent = ['하이큐 10권', '우리가 빛의 속도로 갈 수 없다면', '천 개의 파랑'];
+  const [recent, setRecent] = useState<RecentType[]>([]);
+
+  useEffect(() => {
+    getRecentSearch('booktitle', 1, 10).then((data) => {
+      setRecent(data.data.searchHistory);
+    });
+  }, []);
 
   return (
     <div className="flex h-full flex-col bg-bg">
@@ -25,7 +38,7 @@ const BookSearch = () => {
           <p className="px-[10px] text-body3 font-bold text-white">최근 검색</p>
           <div className="flex flex-col gap-[5px]">
             {recent.map((book, index) => (
-              <RecentSearch name={book} key={index} />
+              <RecentSearch name={book.searchWord} key={index} />
             ))}
           </div>
         </div>

--- a/src/pages/Booksnap/BookSnap.tsx
+++ b/src/pages/Booksnap/BookSnap.tsx
@@ -7,6 +7,7 @@ import WriteButton from '../../components/Booksnap/WriteButton';
 import { getReview } from '../../api/booksnap.api';
 import Toast from '../../components/Common/Toast';
 import BooksnapHeader from '../../components/Header/BooksnapHeader';
+import { useScrollRef } from '../../components/scrollContext';
 
 const BookSnap = () => {
   const [filter, setFilter] = useState<FilterType>('createdAt');
@@ -14,9 +15,9 @@ const BookSnap = () => {
   const [page, setPage] = useState(1);
   const [isLast, setIsLast] = useState<boolean>(false);
   const [isBottom, setIsBottom] = useState<boolean>(false);
-  const mainRef = useRef<HTMLDivElement>(null);
   const isLastRef = useRef<boolean>(false);
   const [isLoading, setIsLoading] = useState(false);
+  const mainRef = useScrollRef();
 
   // 리뷰 목록 받아오기
   const getReviews = async () => {
@@ -59,32 +60,26 @@ const BookSnap = () => {
     isLastRef.current = isLast;
   }, [isLast]);
 
-  // 바닥 감지
-  const detectBottom = () => {
-    if (mainRef.current) {
-      const { scrollTop, clientHeight, scrollHeight } = mainRef.current;
-      return scrollHeight > clientHeight && scrollTop + clientHeight >= scrollHeight - 1;
-    }
-    return false;
-  };
-
-  // 스크롤이 바닥에 있고, 마지막 페이지가 아니면 page + 1
-  const handleScrollEvent = () => {
-    if (detectBottom() && !isBottom && !isLastRef.current) {
-      setIsBottom(true);
-      setPage((prev) => prev + 1);
-    }
-  };
-
-  // 스크롤 이벤트 등록
   useEffect(() => {
-    if (mainRef.current) {
-      mainRef.current.addEventListener('scroll', handleScrollEvent);
-      return () => {
-        mainRef.current?.removeEventListener('scroll', handleScrollEvent);
-      };
+    const handleScroll = () => {
+      if (!mainRef.current) return;
+
+      const { scrollTop, clientHeight, scrollHeight } = mainRef.current;
+      if (scrollTop + clientHeight >= scrollHeight - 100 && !isBottom && !isLastRef.current) {
+        setIsBottom(true);
+        setPage((prev) => prev + 1);
+      }
+    };
+
+    const el = mainRef.current;
+    if (el) {
+      el.addEventListener('scroll', handleScroll);
     }
-  }, []);
+
+    return () => {
+      el?.removeEventListener('scroll', handleScroll);
+    };
+  }, [mainRef, isBottom]);
 
   if (isLoading) {
     return <Loading text="리뷰 목록을 불러오는 중입니다!" />;
@@ -95,7 +90,7 @@ const BookSnap = () => {
   }
 
   return (
-    <div ref={mainRef} className="h-screen overflow-y-auto bg-bg scrollbar-none">
+    <div className="overflow-hidden bg-bg scrollbar-none">
       {/* 헤더 */}
       <BooksnapHeader />
       <div className="mt-[50px] flex flex-col">

--- a/src/pages/Booksnap/BookSnap.tsx
+++ b/src/pages/Booksnap/BookSnap.tsx
@@ -4,10 +4,11 @@ import ReviewPreview from '../../components/Booksnap/ReviewPreview';
 import { BooksnapPreview } from '../../model/booksnap.model';
 import Loading from '../Loading';
 import WriteButton from '../../components/Booksnap/WriteButton';
-import { getReview } from '../../api/booksnap.api';
+import { getReview, searchReview } from '../../api/booksnap.api';
 import Toast from '../../components/Common/Toast';
 import BooksnapHeader from '../../components/Header/BooksnapHeader';
-import { useScrollRef } from '../../components/scrollContext';
+import { useScrollRef } from '../../components/ScrollContext';
+import { useSearchParams } from 'react-router-dom';
 
 const BookSnap = () => {
   const [filter, setFilter] = useState<FilterType>('createdAt');
@@ -18,6 +19,16 @@ const BookSnap = () => {
   const isLastRef = useRef<boolean>(false);
   const [isLoading, setIsLoading] = useState(false);
   const mainRef = useScrollRef();
+  const [searchParams] = useSearchParams();
+  const query = searchParams.get('query');
+
+  useEffect(() => {
+    if (query) {
+      searchReview(query).then((data) => {
+        setReview(data.booksnapPreview);
+      });
+    }
+  }, [query]);
 
   // 리뷰 목록 받아오기
   const getReviews = async () => {
@@ -36,6 +47,7 @@ const BookSnap = () => {
 
   // filter가 변경될 때 상태 초기화 및 getReviews 호출
   useEffect(() => {
+    if (query) return;
     setReview([]);
     setIsLast(false);
     setIsBottom(false);
@@ -49,6 +61,8 @@ const BookSnap = () => {
 
   // page가 변경될 때만 getReviews 호출
   useEffect(() => {
+    if (query) return;
+
     if (page !== 1 || review.length === 0) {
       // 🔄 리뷰가 없거나 페이지가 1이 아닐 때만 호출
       getReviews();


### PR DESCRIPTION
## 🔥 Issues
#32 

## ✅ What to do

- [x] 서점 상세 정보 api 경로 오타 수정
- [x] 북스냅 스크롤 오류 해결
- [x] 북스냅 책 리뷰 검색
- [x] 책 검색 기록 저장 및 불러오기
- [x] 닉네임 저장 및 부키에서 사용

## 📄 Description
* 북스냅에서 스크롤이 인식되지 않아 리뷰가 일부만 보이던 문제 해결
* 북스냅 내 책 리뷰 검색 기능 구현
* 최근 검색어 기록 저장 및 자동 불러오기 기능 구현
* 닉네임을 로컬에 저장하고, 부키 페이지에서 이를 불러와 사용자 맞춤 메시지에 활용

## 🤔 Considerations
### 🔍 스크롤 문제
* 리뷰를 계속 불러와야 하는 무한 스크롤 기능이 동작하지 않는 현상이 있었음
* 디버깅 결과, Layout 컴포넌트의 <main> 요소가 스크롤의 주체가 되어 BookSnap 내의 스크롤 이벤트가 감지되지 않았음
* 이 문제를 해결하기 위해 `useContext`를 사용하여, Layout에서 `mainRef`를 전달하고 BookSnap에서 이를 받아 스크롤 이벤트를 감지하도록 수정함

### 🔎 책 리뷰 검색 전달 구조
* 북스냅 구조상 검색 페이지 → 북스냅으로 검색 결과를 전달해야 했는데, 컴포넌트 depth가 깊어 props로 전달하기 어려웠음
* 고민 끝에, 검색어를 URL 쿼리 파라미터`(?query=...)`로 전달하기로 결정함
* 이는 props drilling 없이도 쉽게 접근 가능하고, 검색 결과를 공유할 수 있는 이점도 있음
* BookSnap 컴포넌트에서는 `useSearchParams`를 통해 query 값을 받아 처리하고, query가 존재하면 기존 전체 리뷰 로딩을 skip하도록 조건 분기하여 검색 결과만 표시되도록 함.

## 🛠️ Improvements to Make
* 현재 검색했을 때, 결과만 보이고 검색어가 보이지 않는다. 검색했을 때 UI를 수정해야겠다.
* 최근 검색어를 눌렀을 때 아무일도 일어나지 않는다. 최근 검색어를 눌렀을 때 검색이 되든가, 검색창에 띄워주게 해야겠다.
## 👀 References

스크린샷 또는 참고사항
<img width="311" alt="image" src="https://github.com/user-attachments/assets/463df02b-6172-4975-aeb1-52d7a55187c0" />
