### PR TITLE
[Feat] 북스냅 검색 UI 변경 및 최근 검색어 누르면 검색창에 반영

### DIFF
--- a/src/api/booksnap.api.ts
+++ b/src/api/booksnap.api.ts
@@ -128,21 +128,6 @@ export const searchReview = async (bookName: string) => {
   }
 };
 
-// 책 검색 기록 저장
-export const postSearchHistory = async (searchType: string, searchWord: string) => {
-  try {
-    const response = await instance.post(`/api/search-history`, {
-      searchType: searchType,
-      searchWord: searchWord,
-    });
-    if (response.status === 200) {
-      return response.data;
-    }
-  } catch (err) {
-    console.log(err);
-  }
-};
-
 // 최근 검색어 불러오기
 export const getRecentSearch = async (searchtype: string, page: number, size: number) => {
   try {

--- a/src/components/Booksnap/RecentSearch.tsx
+++ b/src/components/Booksnap/RecentSearch.tsx
@@ -3,11 +3,12 @@ import { IoTrashSharp } from 'react-icons/io5';
 
 interface RecentSearchProps {
   name: string;
+  onClick: (book: string) => void;
 }
 
-const RecentSearch = ({ name }: RecentSearchProps) => {
+const RecentSearch = ({ name, onClick }: RecentSearchProps) => {
   return (
-    <div className="flex justify-around gap-[10px] p-[10px]">
+    <div className="flex cursor-pointer justify-around gap-[10px] p-[10px]" onClick={() => onClick(name)}>
       <IoMdTime className="h-6 w-6 fill-[#A09F9F]" />
       <p className="flex-1 text-[#A09F9F]">{name}</p>
       <IoTrashSharp className="h-5 w-5 fill-[#A09F9F]" />

--- a/src/components/Header/BookSearchHeader.tsx
+++ b/src/components/Header/BookSearchHeader.tsx
@@ -4,8 +4,12 @@ import Arrow from '../../../public/icons/menu-bar/ArrowLeft.svg?react';
 import { useNavigate } from 'react-router-dom';
 import SearchBar from '../Zip/SearchBar';
 
-const BookSearchHeader = () => {
-  const [searchWord, setSearchWord] = useState('');
+interface BookSearchHeaderProps {
+  query?: string;
+}
+
+const BookSearchHeader = ({ query }: BookSearchHeaderProps) => {
+  const [searchWord, setSearchWord] = useState(query || '');
   const nav = useNavigate();
 
   const handleSearch = () => {
@@ -14,7 +18,7 @@ const BookSearchHeader = () => {
 
   return (
     <div className="fixed left-0 right-0 top-0 z-20 m-auto flex max-w-[500px] items-center gap-[15px] border-b-[1px] border-[#544F4F] bg-bg px-[20px] py-[10px]">
-      <Arrow onClick={() => nav(-1)} />
+      <Arrow onClick={() => nav('/booksnap')} />
       <SearchBar
         searchWord={searchWord}
         setSearchWord={setSearchWord}

--- a/src/components/Header/BookSearchHeader.tsx
+++ b/src/components/Header/BookSearchHeader.tsx
@@ -3,7 +3,6 @@ import Arrow from '../../../public/icons/menu-bar/ArrowLeft.svg?react';
 
 import { useNavigate } from 'react-router-dom';
 import SearchBar from '../Zip/SearchBar';
-import { postSearchHistory } from '../../api/booksnap.api';
 
 const BookSearchHeader = () => {
   const [searchWord, setSearchWord] = useState('');
@@ -11,7 +10,6 @@ const BookSearchHeader = () => {
 
   const handleSearch = () => {
     nav(`/booksnap?query=${searchWord}`);
-    postSearchHistory('booktitle', searchWord);
   };
 
   return (

--- a/src/components/Header/BookSearchHeader.tsx
+++ b/src/components/Header/BookSearchHeader.tsx
@@ -1,6 +1,5 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Arrow from '../../../public/icons/menu-bar/ArrowLeft.svg?react';
-
 import { useNavigate } from 'react-router-dom';
 import SearchBar from '../Zip/SearchBar';
 
@@ -11,6 +10,12 @@ interface BookSearchHeaderProps {
 const BookSearchHeader = ({ query }: BookSearchHeaderProps) => {
   const [searchWord, setSearchWord] = useState(query || '');
   const nav = useNavigate();
+
+  useEffect(() => {
+    if (query !== undefined) {
+      setSearchWord(query);
+    }
+  }, [query]);
 
   const handleSearch = () => {
     nav(`/booksnap?query=${searchWord}`);
@@ -24,7 +29,7 @@ const BookSearchHeader = ({ query }: BookSearchHeaderProps) => {
         setSearchWord={setSearchWord}
         onSearch={handleSearch}
         text="책 제목으로 리뷰를 찾아보세요!"
-      ></SearchBar>
+      />
     </div>
   );
 };

--- a/src/pages/Booksnap/BookSearch.tsx
+++ b/src/pages/Booksnap/BookSearch.tsx
@@ -12,6 +12,7 @@ interface RecentType {
 const BookSearch = () => {
   const bookname = ['구원의 날', '지구에서 한아뿐', '사이키쿠스오'];
   const [recent, setRecent] = useState<RecentType[]>([]);
+  const [word, setWord] = useState('');
 
   useEffect(() => {
     getRecentSearch('booktitle', 1, 10).then((data) => {
@@ -19,10 +20,14 @@ const BookSearch = () => {
     });
   }, []);
 
+  const handleClick = (bookName: string) => {
+    setWord(bookName);
+  };
+
   return (
     <div className="flex h-full flex-col bg-bg">
       {/* 헤더 */}
-      <BookSearchHeader />
+      <BookSearchHeader query={word} />
       <div className="mt-[53px] flex flex-col gap-[15px] bg-bg px-[15px] py-[10px]">
         {/* 인기 검색어 */}
         <div className="flex w-full flex-col gap-[10px] border-b-[1px] border-[#A09F9F] p-[10px] text-body3 font-bold text-white">
@@ -38,7 +43,7 @@ const BookSearch = () => {
           <p className="px-[10px] text-body3 font-bold text-white">최근 검색</p>
           <div className="flex flex-col gap-[5px]">
             {recent.map((book, index) => (
-              <RecentSearch name={book.searchWord} key={index} />
+              <RecentSearch name={book.searchWord} key={index} onClick={() => handleClick(book.searchWord)} />
             ))}
           </div>
         </div>

--- a/src/pages/Booksnap/BookSnap.tsx
+++ b/src/pages/Booksnap/BookSnap.tsx
@@ -9,26 +9,18 @@ import Toast from '../../components/Common/Toast';
 import BooksnapHeader from '../../components/Header/BooksnapHeader';
 import { useScrollRef } from '../../components/ScrollContext';
 import { useSearchParams } from 'react-router-dom';
+import BookSearchHeader from '../../components/Header/BookSearchHeader';
 
 const BookSnap = () => {
   const [filter, setFilter] = useState<FilterType>('createdAt');
   const [review, setReview] = useState<BooksnapPreview[]>([]);
   const [page, setPage] = useState(1);
-  const [isLast, setIsLast] = useState<boolean>(false);
-  const [isBottom, setIsBottom] = useState<boolean>(false);
-  const isLastRef = useRef<boolean>(false);
+  const [isLast, setIsLast] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const isLastRef = useRef(false);
   const mainRef = useScrollRef();
   const [searchParams] = useSearchParams();
   const query = searchParams.get('query');
-
-  useEffect(() => {
-    if (query) {
-      searchReview(query).then((data) => {
-        setReview(data.booksnapPreview);
-      });
-    }
-  }, [query]);
 
   // 리뷰 목록 받아오기
   const getReviews = async () => {
@@ -37,7 +29,6 @@ const BookSnap = () => {
       const data = await getReview(filter, page);
       setReview((prev) => (page === 1 ? data.data.booksnapPreview : [...prev, ...data.data.booksnapPreview]));
       setIsLast(data.data.last);
-      setIsBottom(false);
     } catch (error) {
       console.error('리뷰를 불러오는 중 에러 발생:', error);
     } finally {
@@ -45,12 +36,22 @@ const BookSnap = () => {
     }
   };
 
-  // filter가 변경될 때 상태 초기화 및 getReviews 호출
+  // 검색어 있을 때는 검색 API 호출
+  useEffect(() => {
+    setReview([]);
+    if (query) {
+      searchReview(query).then((data) => {
+        setReview(data.booksnapPreview);
+      });
+    } else {
+      getReviews();
+    }
+  }, [query]);
+
   useEffect(() => {
     if (query) return;
     setReview([]);
     setIsLast(false);
-    setIsBottom(false);
 
     if (page !== 1) {
       setPage(1); // page가 1이 아니면 1로 초기화 (getReviews는 page가 바뀔 때 호출됨)
@@ -59,28 +60,26 @@ const BookSnap = () => {
     }
   }, [filter]);
 
-  // page가 변경될 때만 getReviews 호출
+  // page가 바뀌면 getReviews 호출
   useEffect(() => {
     if (query) return;
-
-    if (page !== 1 || review.length === 0) {
-      // 🔄 리뷰가 없거나 페이지가 1이 아닐 때만 호출
-      getReviews();
-    }
+    getReviews();
   }, [page]);
 
-  // isLast 업데이트 시 참조 업데이트
+  // isLast 상태를 ref에도 반영
   useEffect(() => {
     isLastRef.current = isLast;
   }, [isLast]);
 
+  // 스크롤 이벤트 등록
   useEffect(() => {
     const handleScroll = () => {
       if (!mainRef.current) return;
 
       const { scrollTop, clientHeight, scrollHeight } = mainRef.current;
-      if (scrollTop + clientHeight >= scrollHeight - 100 && !isBottom && !isLastRef.current) {
-        setIsBottom(true);
+      const nearBottom = scrollTop + clientHeight >= scrollHeight - 100;
+
+      if (nearBottom && !isLastRef.current && !isLoading) {
         setPage((prev) => prev + 1);
       }
     };
@@ -93,9 +92,9 @@ const BookSnap = () => {
     return () => {
       el?.removeEventListener('scroll', handleScroll);
     };
-  }, [mainRef, isBottom]);
+  }, [mainRef, isLoading]);
 
-  if (isLoading) {
+  if (isLoading && review.length === 0) {
     return <Loading text="리뷰 목록을 불러오는 중입니다!" />;
   }
 
@@ -106,9 +105,9 @@ const BookSnap = () => {
   return (
     <div className="overflow-hidden bg-bg scrollbar-none">
       {/* 헤더 */}
-      <BooksnapHeader />
-      <div className="mt-[50px] flex flex-col">
-        <FilterBar filter={filter} setFilter={setFilter} />
+      {query ? <BookSearchHeader query={query} /> : <BooksnapHeader />}
+      <div className={`flex flex-col ${query ? '' : 'mt-[50px]'}`}>
+        {!query && <FilterBar filter={filter} setFilter={setFilter} />}
         <div className="mt-8 flex flex-col gap-6 px-8 py-8">
           {review.map((preview, index) => (
             <ReviewPreview review={preview} key={index} />


### PR DESCRIPTION
## 🔥 Issues
#33 

## ✅ What to do

- [x] 검색어 저장 API 호출 제거
- [x] 북스냅 검색 결과 헤더 UI 수정
- [x] 북스냅 스크롤 튕기는 오류 수정
- [x] 북스냅 최근 검색어 누르면 검색창에 반영

## 📄 Description
* 검색어 저장 API가 swagger에 있어서 호출햇는데 알고보니 백엔드 확인용이었고, 검색만 하면 자동으로 검색어는 저장되는 것이었어서 호출을 제거
* 북스냅에서 검색했을 때, 기존에는 검색어가 상단에 뜨지 않아 검색어가 뜨게 헤더를 수정
* 북스냅에서 스크롤이 바닥에 닿으면 다음 페이지를 가져오는데 이때, 스크롤이 최상단으로 가는 오류 수정
* 북스냅 검색에서 최근 검색어 누르면 검색창에 반영

## 🤔 Considerations
### 최근검색어 눌러도 헤더에 반영되지 않는 문제
* 원인은 BookSearchHeader 내부에서 query prop을 받아 초기 `searchWord` 상태로만 설정하고, 이후에는 갱신하지 않아 상태가 고정되는 구조였기 때문
* 이를 해결하기 위해 useEffect를 통해 query 값이 변경될 때마다 searchWord 상태가 동기화되도록 수정

### 스크롤 바닥 시 최상단으로 튀는 문제
* 검색 결과를 무한 스크롤로 구현했는데, 스크롤이 바닥에 닿아 다음 페이지 데이터를 가져오는 순간 스크롤이 갑자기 최상단으로 튀는 현상이 발생
* 초기에는 `setReview([])` 등의 렌더 트리 변경이 원인이라 추정했으나, 실제 원인은 `getReviews()`가 중복 호출되며 불필요한 렌더링이 발생한 것
* isLoading 상태를 활용해 중복 호출을 방지하고, 스크롤 이벤트가 안정적으로 동작하도록 수정


## 🛠️ Improvements to Make

개선할 사항

## 👀 References
<img width="310" alt="image" src="https://github.com/user-attachments/assets/35652207-c9c1-4b8e-bd0f-80a31bce2fc4" />

